### PR TITLE
README.md: "change": "ne" as default

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ You can use following parameters to specify the trigger:
 |             |            |                                                                                                        |
 | change      | string     |       "eq", "ne", "gt", "ge", "lt", "le", "any"                                                        |
 |             |   "eq"     |       (equal)            New value must be euqal to old one (state.val == oldState.val)             |
-|             |   "ne"     |       (not equal)        New value must be not equal to the old one (state.val != oldState.val) **If "change" is not specified this value is used by default**    |
+|             |   "ne"     |       (not equal)        New value must be not equal to the old one (state.val != oldState.val) **If pattern is not a object this value is used by default**    |
 |             |   "gt"     |       (greater)          New value must be greater than old value (state.val > oldState.val)        |
 |             |   "ge"     |       (greater or equal) New value must be greater or euqal to old one (state.val >= oldState.val)  |
 |             |   "lt"     |       (smaller)          New value must be smaller than old one (state.val < oldState.val)          |


### PR DESCRIPTION
```
               if (typeof pattern !== 'object' || pattern instanceof RegExp || pattern.source) {
                    pattern = {id: pattern, change: 'ne'};
                }
```
Was ist pattern.source ?
Wäre es nicht besser, so zu testen, damit die README.md nicht geändert werden muss ?
```
                if (typeof pattern === 'string' || pattern instanceof RegExp) {
                    pattern = {id: pattern, change: 'ne'};
                }
                else if (typeof pattern === 'object' && pattern.change  === undefined) {
                    pattern.change = 'ne';
                }
```