### PR TITLE
more meaningful warn message on bad endTime expression

### DIFF
--- a/javascript.js
+++ b/javascript.js
@@ -2424,6 +2424,10 @@
 
                 if (endTime) endTime = endTime.getTime();
 
+                if(operation === 'between' && !endTime) {
+                    adapter.log.warn("missing or unrecognized endTime expression: "+endTime);
+                    return false;
+                }
                 if (operation === 'between' && endTime) {
 		            if (startTime > endTime && daily) return !(time >= endTime && time < startTime);
                       else return time >= startTime && time < endTime;


### PR DESCRIPTION
When endTime in compareTime(startTime,endTime,'between')  is wrong, the warn message in the log is somewhat misleading ("warn - invalid operator: between").
With this small patch, it gives "missing or unrecognized endTime expression" instead.
