### PR TITLE
TypeScript support

### DIFF
--- a/admin/tab.js
+++ b/admin/tab.js
@@ -421,6 +421,8 @@ function Scripts(main) {
             that.editor.getSession().setMode('ace/mode/javascript');
         } else if (that.currentEngine.match(/^[cC]offee[sS]cript/)) {
             that.editor.getSession().setMode('ace/mode/coffee');
+        } else if (that.currentEngine.match(/^[tT]ype[sS]cript/)) {
+            that.editor.getSession().setMode('ace/mode/typescript');
         }
     }
 
@@ -830,6 +832,11 @@ function Scripts(main) {
                 switchViews(false, obj.common.engineType);
             } else if (obj.common.engineType && obj.common.engineType.match(/^[cC]offee[sS]cript/)) {
                 that.editor.getSession().setMode('ace/mode/coffee');
+                that.editor.getSession().setUseWorker(true); // enable syntax check
+                that.editor.setReadOnly(false);
+                switchViews(false, obj.common.engineType);
+            } else if (obj.common.engineType && obj.common.engineType.match(/^[tT]ype[sS]cript/)) {
+                that.editor.getSession().setMode('ace/mode/typescript');
                 that.editor.getSession().setUseWorker(true); // enable syntax check
                 that.editor.setReadOnly(false);
                 switchViews(false, obj.common.engineType);

--- a/io-package.json
+++ b/io-package.json
@@ -155,6 +155,7 @@
         "keywords": [
             "js",
             "javascript",
+            "typescript",
             "coffeescript",
             "rules",
             "automate",
@@ -168,7 +169,8 @@
         "engineTypes": [
             "Blockly",
             "Javascript/js",
-            "Coffeescript/coffee"
+            "Coffeescript/coffee",
+            "TypeScript/ts"
         ],
         "adminTab": {
             "singleton": true,
@@ -195,7 +197,7 @@
             "language": "javascript",
             "views": {
                 "javascript": {
-                    "map": "function(doc) { if (doc.type === 'script' && doc.common.engineType.match(/^[jJ]ava[sS]cript|^[cC]offee[sS]cript|^Blockly/)) emit(doc.common.name, doc); }"
+                    "map": "function(doc) { if (doc.type === 'script' && doc.common.engineType.match(/^[jJ]ava[sS]cript|^[cC]offee[sS]cript|^[tT]ype[sS]cript|^Blockly/)) emit(doc.common.name, doc); }"
                 }
             }
         }

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "coffee-compiler": "^0.3.2",
     "coffee-script": ">=1.12.3",
     "typescript": "^2.5.3",
-    "virtual-tsc": "^0.2.2",
+    "virtual-tsc": "^0.2.3",
     "@types/node": "^8.0.34"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,10 @@
     "suncalc": "^1.8.0",
     "wake_on_lan": "0.0.4",
     "coffee-compiler": "^0.3.2",
-    "coffee-script": ">=1.12.3"
+    "coffee-script": ">=1.12.3",
+    "typescript": "^2.5.3",
+    "virtual-tsc": "^0.2.2",
+    "@types/node": "^8.0.34"
   },
   "devDependencies": {
     "grunt": "^1.0.1",


### PR DESCRIPTION
Erster Versuch, TypeScript zu unterstützen. Ist **noch ungetestet**, werde ich heute Abend tun. 
Falls jemand schon was auffällt, bitte Bescheid geben.

Schön wäre noch eine Möglichkeit, `@types/node` automatisch in der richtigen Version zu installieren.

Ambient declarations für die Adapter-Funktionen sind im Moment noch optional, sollte aber in Zukunft erzwungen werden.