### PR TITLE
Massively speed up TypeScript compilation

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "coffee-compiler": "^0.3.2",
     "coffee-script": ">=1.12.3",
     "typescript": "^2.5.3",
-    "virtual-tsc": "^0.2.3",
+    "virtual-tsc": "^0.3.2",
     "@types/node": "^8.0.34"
   },
   "devDependencies": {


### PR DESCRIPTION
As the compilations are pretty slow (~10-20s on a Raspberry), I looked into speeding it up. 

Using incremental compilation, I went from ~700ms per compilation on my windows PC down to ~300ms for the first one and 2-4ms for every one after that.