### PR TITLE
Fix TypeScript module resolution (again)

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "coffee-compiler": "^0.3.2",
     "coffee-script": ">=1.12.3",
     "typescript": "^2.5.3",
-    "virtual-tsc": "^0.3.3",
+    "virtual-tsc": "^0.3.4",
     "@types/node": "^8.0.34"
   },
   "devDependencies": {


### PR DESCRIPTION
Found a couple of issues while playing around with TypeScript:

1. When importing node modules in TypeScript, the VM was choking on the auto-generated `module.exports`. Thus, the generated code is now wrapped in an IIFE which provides an empty object for `exports`.
2. Output from the virtual TS compiler is now redirected to the debug log
3. The path of the compiled scripts is now prepended with the current `__dirname`, so the module resolution works.

--

One more thing: Since we're now targeting Node 4+, it should be fine to use `let/const`, right?