### PR TITLE
Missing Parameter in setState and setStateDelay of callback

### DIFF
--- a/lib/javascript.d.ts
+++ b/lib/javascript.d.ts
@@ -339,7 +339,7 @@ declare global {
 	 * Sets a state to the given value
 	 * @param id The ID of the state to be set
 	 */
-	function setState(id: string, state: string | number | boolean | iobJS.State | Partial<iobJS.State>, ack?: boolean, callback?: () => void): void;
+	function setState(id: string, state: string | number | boolean | iobJS.State | Partial<iobJS.State>, ack?: boolean, callback?: iobJS.SetStateCallback): void;
 
 	/**
 	 * Sets a state to the given value after a timeout has passed.
@@ -348,7 +348,7 @@ declare global {
 	 * @param delay The delay in milliseconds
 	 * @param clearRunning (optional) Whether an existing timeout for this state should be cleared
 	 */
-	function setStateDelayed(id: string, state: string | number | boolean | iobJS.State | Partial<iobJS.State>, ack: boolean, delay: number, clearRunning?: boolean, callback?: () => void): any;
+	function setStateDelayed(id: string, state: string | number | boolean | iobJS.State | Partial<iobJS.State>, ack: boolean, delay: number, clearRunning?: boolean, callback?: iobJS.SetStateCallback): any;
 	
 	/**
 	 * Clears a timer created by setStateDelayed


### PR DESCRIPTION
callback of setState and setStateDelayed sometimes have a parameter with the error.