### PR TITLE
Polyfill `exports` in the sandbox

### DIFF
--- a/javascript.js
+++ b/javascript.js
@@ -302,9 +302,7 @@ const adapter = new utils.Adapter({
                 }
 
                 adapter.objects.getObjectView('script', 'javascript', {}, (err, doc) => {
-                    // we have to make sure the VM doesn't choke on `exports` when using TypeScript
-                    // even when there's no global script, this line has to exist:
-                    globalScript = '';//'const exports = {};\n';
+                    globalScript = '';
                     let count = 0;
                     if (doc && doc.rows && doc.rows.length) {
                         // assemble global script

--- a/lib/sandbox.js
+++ b/lib/sandbox.js
@@ -118,6 +118,7 @@ function sandBox(script, name, verbose, debug, context) {
         instance:  adapter.instance,
         verbose:   verbose,
         request:   mods.request,
+        exports:   {}, // Polyfill for the exports object in TypeScript modules
         require:   function (md) {
             console.log('REQUIRE: ' + md);
             if (mods[md]) {


### PR DESCRIPTION
This fixes scripts created with TypeScript not being able to access `exports` when importing modules.

Fixes: #118 