### PR TITLE
TypeScript: Generate declarations for global scripts

### DIFF
--- a/main.js
+++ b/main.js
@@ -540,15 +540,22 @@ let globalScriptLines  = 0;
 let activeRegEx        = null;
 let activeStr          = '';
 
-// compiler instance for typescript
-/** @param {string} sev */
+/**
+ * Redirects the virtual-tsc log output to the ioBroker log
+ * @param {string} sev
+ */
 function tsLog(msg, sev) {
+    // shift the severities around, we don't care about the small details
+    if (sev == null || sev === 'info') sev = 'debug';
+    else if (sev === 'debug') sev = 'silly';
+
     if (adapter && adapter.log) {
-        adapter.log[sev || 'info'](msg);
+        adapter.log[sev](msg);
     } else {
         console.log(`[${sev.toUpperCase()}] ${msg}`);
     }
 }
+// compiler instance for typescript
 tsServer = new tsc.Server(tsCompilerOptions, tsLog);
 // compiler instance for global JS declarations
 jsDeclarationServer = new tsc.Server(jsDeclarationCompilerOptions);

--- a/main.js
+++ b/main.js
@@ -70,6 +70,7 @@ if (process.argv) {
     }
 }
 
+/** @type {typescript.CompilerOptions} */
 const tsCompilerOptions = {
     // don't compile faulty scripts
     noEmitOnError: true,
@@ -78,6 +79,7 @@ const tsCompilerOptions = {
     // support for NodeJS 6+. Consider changing it to
     // a higher version when support for NodeJS 6 is dropped
     target: typescript.ScriptTarget.ES2015,
+    lib: ['lib.es2015.d.ts'],
 };
 const jsDeclarationCompilerOptions = Object.assign(
     {}, tsCompilerOptions,
@@ -539,8 +541,13 @@ let activeRegEx        = null;
 let activeStr          = '';
 
 // compiler instance for typescript
+/** @param {string} sev */
 function tsLog(msg, sev) {
-    if (adapter && adapter.log) adapter.log[sev || 'info'](msg);
+    if (adapter && adapter.log) {
+        adapter.log[sev || 'info'](msg);
+    } else {
+        console.log(`[${sev.toUpperCase()}] ${msg}`);
+    }
 }
 tsServer = new tsc.Server(tsCompilerOptions, tsLog);
 // compiler instance for global JS declarations

--- a/package.json
+++ b/package.json
@@ -25,14 +25,13 @@
     "vm2": "^3.5.2"
   },
   "dependencies": {
-    "@types/node": "^8.0.34",
     "coffee-compiler": "^0.3.2",
     "coffee-script": ">=1.12.3",
     "node-schedule": "1.3.0",
     "request": "^2.85.0",
     "suncalc": "^1.8.0",
     "typescript": "^2.8.3",
-    "virtual-tsc": "^0.4.1",
+    "virtual-tsc": "^0.4.2",
     "wake_on_lan": "0.0.4"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "request": "^2.85.0",
     "suncalc": "^1.8.0",
     "typescript": "^2.8.3",
-    "virtual-tsc": "^0.4.0",
+    "virtual-tsc": "^0.4.1",
     "wake_on_lan": "0.0.4"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "request": "^2.85.0",
     "suncalc": "^1.8.0",
     "typescript": "^2.8.3",
-    "virtual-tsc": "^0.4.4",
+    "virtual-tsc": "^0.4.5",
     "wake_on_lan": "0.0.4"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "request": "^2.85.0",
     "suncalc": "^1.8.0",
     "typescript": "^2.8.3",
-    "virtual-tsc": "^0.4.2",
+    "virtual-tsc": "^0.4.4",
     "wake_on_lan": "0.0.4"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "request": "^2.85.0",
     "suncalc": "^1.8.0",
     "typescript": "^2.8.3",
-    "virtual-tsc": "^0.3.4",
+    "virtual-tsc": "^0.4.0",
     "wake_on_lan": "0.0.4"
   },
   "devDependencies": {


### PR DESCRIPTION
This allows TypeScripts to access functions and variables defined in global scripts (TS and JS) without declaring them again.

First part of #120