### PR TITLE
Better check for undefined variables inside $ selector

### DIFF
--- a/lib/sandbox.js
+++ b/lib/sandbox.js
@@ -352,7 +352,8 @@ function sandBox(script, name, verbose, debug, context) {
             let pass;
             if (name === 'channel') {
                 for (const id in context.channels) {
-                    if (!context.channels.hasOwnProperty(id) || !objects.hasOwnProperty(id)) continue;
+                    if (!context.channels.hasOwnProperty(id) || context.channels[id] == null) continue;
+                    if (!objects.hasOwnProperty(id) || objects[id] == null) continue;
                     pass = true;
                     for (let c = 0; c < commons.length; c++) {
                         if (!commons[c]) continue;
@@ -419,10 +420,8 @@ function sandBox(script, name, verbose, debug, context) {
                 }
             } else if (name === 'device') {
                 for (const id in context.devices) {
-                    if (!context.devices.hasOwnProperty(id) || !objects[id]) {
-                        console.log(id);
-                        continue;
-                    }
+                    if (!context.devices.hasOwnProperty(id) || context.devices[id] == null) continue;
+                    if (!objects.hasOwnProperty(id) || objects[id] == null) continue;
                     pass = true;
                     for (let _c = 0; _c < commons.length; _c++) {
                         if (!commons[_c]) continue;
@@ -495,6 +494,8 @@ function sandBox(script, name, verbose, debug, context) {
                 // state
                 for (let s = 0; s < context.stateIds.length; s++) {
                     const id = context.stateIds[s];
+                    if (!context.stateIds.hasOwnProperty(id) || context.stateIds[id] == null) continue;
+                    if (!objects.hasOwnProperty(id) || objects[id] == null) continue;
                     if (r && !r.test(id)) continue;
                     pass = true;
 


### PR DESCRIPTION
The check for undefined objects is different between `device`s, `channel`s and `state`s. This PR attempts to unify the behavior and catch the error described in #135 

@GermanBluefox does this look reasonable? So far I've always skipped over the `$` function because its such a huge chunk of code.

Fixes: #135 