### PR TITLE
Refactor $ selector

### DIFF
--- a/lib/sandbox.js
+++ b/lib/sandbox.js
@@ -111,6 +111,48 @@ function sandBox(script, name, verbose, debug, context) {
         return functions;
     }
 
+    /** @typedef {{attr: string, value: string, idRegExp?: RegExp}} Selector */
+    /**
+     * Splits a selector string into attribute and value
+     * @param {string} selector The selector string to split
+     * @returns {Selector}
+     */
+    function splitSelectorString(selector) {
+        const parts = selector.split('=', 2);
+        if (parts[1] && parts[1][0] === '"') {
+            parts[1] = parts[1].substring(1);
+            const len = parts[1].length;
+            if (parts[1] && parts[1][len - 1] === '"') parts[1] = parts[1].substring(0, len - 1);
+        }
+        if (parts[1] && parts[1][0] === "'") {
+            parts[1] = parts[1].substring(1);
+            const len = parts[1].length;
+            if (parts[1] && parts[1][len - 1] === "'") parts[1] = parts[1].substring(0, len - 1);
+        }
+
+        if (parts[1]) parts[1] = parts[1].trim();
+        parts[0] = parts[0].trim();
+
+        return {attr: parts[0], value: parts[1]};
+    }
+
+    /**
+     * Adds a regular expression for selectors targeting the state ID
+     * @param {Selector} selector The selector to apply the transform to
+     * @returns {Selector}
+     */
+    function addRegExpToIdAttrSelectors(selector) {
+        if (!selector.idRegExp && selector.value) {
+            return {
+                attr: selector.attr,
+                value: selector.value,
+                idRegExp: new RegExp('^' + selector.value.replace(/\./g, '\\.').replace(/\*/g, '.*') + '$')
+            };
+        } else {
+            return selector;
+        }
+    }
+
     const sandbox = {
         mods:      mods,
         _id:       script._id,
@@ -254,75 +296,33 @@ function sandBox(script, name, verbose, debug, context) {
                 return result;
             }
 
-            /** @typedef {{attr: string, value: string, r?: RegExp}} Selector */
-            /**
-             * Splits a selector string into attribute and value
-             * @param {string} selector The selector string to split
-             * @returns {Selector}
-             */
-            function splitSelectorString(selector) {
-                const parts = selector.split('=', 2);
-                if (parts[1] && parts[1][0] === '"') {
-                    parts[1] = parts[1].substring(1);
-                    const len = parts[1].length;
-                    if (parts[1] && parts[1][len - 1] === '"') parts[1] = parts[1].substring(0, len - 1);
-                }
-                if (parts[1] && parts[1][0] === "'") {
-                    parts[1] = parts[1].substring(1);
-                    const len = parts[1].length;
-                    if (parts[1] && parts[1][len - 1] === "'") parts[1] = parts[1].substring(0, len - 1);
-                }
-
-                if (parts[1]) parts[1] = parts[1].trim();
-                parts[0] = parts[0].trim();
-
-                return {attr: parts[0], value: parts[1]};
-            }
-
             /** @type {Selector[]} */
-            const filterStates = [];
-            const commonSelectors = commonStrings
-                .map(common => {
-                    const ret = splitSelectorString(common);
-                    if (ret.attr === 'state.id') {
-                        filterStates.push(ret);
-                        return null;
-                    } else {
-                        return ret;
-                    }
-                })
-                .filter(common => common != null)
-            ;
+            let commonSelectors = commonStrings
+                .map(selector => splitSelectorString(selector))
+                .map(selector => addRegExpToIdAttrSelectors(selector))
+                ;
+            let nativeSelectors = nativeStrings
+                .map(selector => splitSelectorString(selector))
+                .map(selector => addRegExpToIdAttrSelectors(selector))
+                ;
+            const enumSelectorObjects = enumStrings.map(_enum => splitSelectorString(_enum));
 
-            const nativeSelectors = nativeStrings
-                .map(native => {
-                    const ret = splitSelectorString(native);
-                    if (ret.attr === 'state.id') {
-                        filterStates.push(ret);
-                        return null;
-                    } else {
-                        return ret;
-                    }
-                })
-                .filter(native => native != null)
+            // All selectors with attr 'state.id' belong into filter states
+            // So filter them out the other selector arrays
+            const filterStates = commonSelectors.concat(nativeSelectors, enumSelectorObjects)
+                .filter(selector => selector.attr === 'state.id')
             ;
-
-            const enumSelectors = enumStrings
-                .map(_enum => {
-                    const ret = splitSelectorString(_enum);
-                    if (ret.attr === 'state.id') {
-                        filterStates.push(ret);
-                        return null;
-                    } else {
-                        return `enum.${ret.attr}.${ret.value}`;
-                    }
-                })
-                .filter(_enum => _enum != null)
+            commonSelectors = commonSelectors.filter(selector => selector.attr !== 'state.id');
+            nativeSelectors = nativeSelectors.filter(selector => selector.attr !== 'state.id');
+            const enumSelectors = enumSelectorObjects
+                .filter(selector => selector.attr !== 'state.id')
+                // enums are filtered by their enum id, so transform the selector into that
+                .map(selector => `enum.${selector.attr}.${selector.value}`)
             ;
 
             name = name.trim();
             if (name === 'channel' || name === 'device') {
-                // Fill channels
+                // Fill the channels and devices objects to loop over them afterwards
                 if (!context.channels || !context.devices) {
                     context.channels = {};
                     context.devices  = {};
@@ -349,13 +349,12 @@ function sandBox(script, name, verbose, debug, context) {
             if (name === 'channel') {
                 channelLoop: for (const id in context.channels) {
                     if (!context.channels.hasOwnProperty(id) || context.channels[id] == null) continue;
-                    if (!objects.hasOwnProperty(id) || objects[id] == null) continue;
 
                     for (const common of commonSelectors) {
                         if (common.attr === 'id') {
-                            if (!common.r && common.value) common.r = new RegExp('^' + common.value.replace(/\./g, '\\.').replace(/\*/g, '.*') + '$');
-                            if (!common.r || common.r.test(id)) continue;
-                        } else if (objects[id].common) {
+                            if (!common.idRegExp && common.value) common.idRegExp = new RegExp('^' + common.value.replace(/\./g, '\\.').replace(/\*/g, '.*') + '$');
+                            if (!common.idRegExp || common.idRegExp.test(id)) continue;
+                        } else if (objects[id] && objects[id].common) {
                             if (common.value === undefined && objects[id].common[common.attr] !== undefined) continue;
                             if (objects[id].common[common.attr] === common.value) continue;
                         }
@@ -365,9 +364,9 @@ function sandBox(script, name, verbose, debug, context) {
                     for (const native of nativeSelectors) {
                         if (!native) continue;
                         if (native.attr === 'id') {
-                            if (!native.r && native.value) native.r = new RegExp('^' + native.value.replace(/\./g, '\\.').replace(/\*/g, '.*') + '$');
-                            if (!native.r || native.r.test(id)) continue;
-                        } else if (objects[id].native) {
+                            if (!native.idRegExp && native.value) native.idRegExp = new RegExp('^' + native.value.replace(/\./g, '\\.').replace(/\*/g, '.*') + '$');
+                            if (!native.idRegExp || native.idRegExp.test(id)) continue;
+                        } else if (objects[id] && objects[id].native) {
                             if (native.value === undefined && objects[id].native[native.attr] !== undefined) continue;
                             if (objects[id].native[native.attr] == native.value) continue;
                         }
@@ -375,7 +374,7 @@ function sandBox(script, name, verbose, debug, context) {
                     }
 
                     if (enumSelectors.length) {
-                        let enumIds = [];
+                        const enumIds = [];
                         eventObj.getObjectEnumsSync(context, id, enumIds);
 
                         for (const _enum of enumSelectors) {
@@ -388,16 +387,16 @@ function sandBox(script, name, verbose, debug, context) {
                     for (const channel of context.channels[id]) {
                         if (filterStates.length) {
                             for (const filterState of filterStates) {
-                                if (!filterState.r && filterState.value) {
+                                if (!filterState.idRegExp && filterState.value) {
                                     if (filterState.value[0] === '*') {
-                                        filterState.r = new RegExp(filterState.value.replace(/\./g, '\\.').replace(/\*/g, '.*') + '$');
+                                        filterState.idRegExp = new RegExp(filterState.value.replace(/\./g, '\\.').replace(/\*/g, '.*') + '$');
                                     } else if (filterState.value[filterState.value.length - 1] === '*') {
-                                        filterState.r = new RegExp('^' + filterState.value.replace(/\./g, '\\.').replace(/\*/g, '.*'));
+                                        filterState.idRegExp = new RegExp('^' + filterState.value.replace(/\./g, '\\.').replace(/\*/g, '.*'));
                                     } else {
-                                        filterState.r = new RegExp(filterState.value.replace(/\./g, '\\.').replace(/\*/g, '.*'));
+                                        filterState.idRegExp = new RegExp(filterState.value.replace(/\./g, '\\.').replace(/\*/g, '.*'));
                                     }
                                 }
-                                if (!filterState.r || filterState.r.test(channel)) continue;
+                                if (!filterState.idRegExp || filterState.idRegExp.test(channel)) continue;
                                 continue channelLoop;
                             }
                         }
@@ -407,13 +406,12 @@ function sandBox(script, name, verbose, debug, context) {
             } else if (name === 'device') {
                 deviceLoop: for (const id in context.devices) {
                     if (!context.devices.hasOwnProperty(id) || context.devices[id] == null) continue;
-                    if (!objects.hasOwnProperty(id) || objects[id] == null) continue;
 
                     for (const common of commonSelectors) {
                         if (common.attr === 'id') {
-                            if (!common.r && common.value) common.r = new RegExp('^' + common.value.replace(/\./g, '\\.').replace(/\*/g, '.*') + '$');
-                            if (!common.r || common.r.test(id)) continue;
-                        } else if (objects[id].common) {
+                            if (!common.idRegExp && common.value) common.idRegExp = new RegExp('^' + common.value.replace(/\./g, '\\.').replace(/\*/g, '.*') + '$');
+                            if (!common.idRegExp || common.idRegExp.test(id)) continue;
+                        } else if (objects[id] && objects[id].common) {
                             if (common.value === undefined && objects[id].common[common.attr] !== undefined) continue;
                             if (objects[id].common[common.attr] == common.value) continue;
                         }
@@ -422,9 +420,9 @@ function sandBox(script, name, verbose, debug, context) {
 
                     for (const native of nativeSelectors) {
                         if (native.attr === 'id') {
-                            if (!native.r && native.value) native.r = new RegExp('^' + native.value.replace(/\./g, '\\.').replace(/\*/g, '.*') + '$');
-                            if (!native.r || native.r.test(id)) continue;
-                        } else if (objects[id].native) {
+                            if (!native.idRegExp && native.value) native.idRegExp = new RegExp('^' + native.value.replace(/\./g, '\\.').replace(/\*/g, '.*') + '$');
+                            if (!native.idRegExp || native.idRegExp.test(id)) continue;
+                        } else if (objects[id] && objects[id].native) {
                             if (native.value === undefined && objects[id].native[native.attr] !== undefined) continue;
                             if (objects[id].native[native.attr] == native.value) continue;
                         }
@@ -432,7 +430,7 @@ function sandBox(script, name, verbose, debug, context) {
                     }
 
                     if (enumSelectors.length) {
-                        let enumIds = [];
+                        const enumIds = [];
                         eventObj.getObjectEnumsSync(context, id, enumIds);
 
                         for (const _enum of enumSelectors) {
@@ -445,16 +443,16 @@ function sandBox(script, name, verbose, debug, context) {
                     for (const device of context.devices[id]) {
                         if (filterStates.length) {
                             for (const filterState of filterStates) {
-                                if (!filterState.r && filterState.value) {
+                                if (!filterState.idRegExp && filterState.value) {
                                     if (filterState.value[0] === '*') {
-                                        filterState.r = new RegExp(filterState.value.replace(/\./g, '\\.').replace(/\*/g, '.*') + '$');
+                                        filterState.idRegExp = new RegExp(filterState.value.replace(/\./g, '\\.').replace(/\*/g, '.*') + '$');
                                     } else if (filterState.value[filterState.value.length - 1] === '*') {
-                                        filterState.r = new RegExp('^' + filterState.value.replace(/\./g, '\\.').replace(/\*/g, '.*'));
+                                        filterState.idRegExp = new RegExp('^' + filterState.value.replace(/\./g, '\\.').replace(/\*/g, '.*'));
                                     } else {
-                                        filterState.r = new RegExp(filterState.value.replace(/\./g, '\\.').replace(/\*/g, '.*'));
+                                        filterState.idRegExp = new RegExp(filterState.value.replace(/\./g, '\\.').replace(/\*/g, '.*'));
                                     }
                                 }
-                                if (!filterState.r || filterState.r.test(device)) continue;
+                                if (!filterState.idRegExp || filterState.idRegExp.test(device)) continue;
                                 continue deviceLoop;
                             }
                         }
@@ -466,14 +464,12 @@ function sandBox(script, name, verbose, debug, context) {
 
                 // state
                 stateLoop: for (const id of context.stateIds) {
-                    if (!context.stateIds.hasOwnProperty(id) || context.stateIds[id] == null) continue;
-                    if (!objects.hasOwnProperty(id) || objects[id] == null) continue;
                     if (r && !r.test(id)) continue;
 
                     for (const common of commonSelectors) {
                         if (common.attr === 'id') {
-                            if (!common.r && common.value) common.r = new RegExp(common.value.replace(/\./g, '\\.').replace(/\*/g, '.*'));
-                            if (!common.r || common.r.test(id)) continue;
+                            if (!common.idRegExp && common.value) common.idRegExp = new RegExp(common.value.replace(/\./g, '\\.').replace(/\*/g, '.*'));
+                            if (!common.idRegExp || common.idRegExp.test(id)) continue;
                         } else if (objects[id] && objects[id].common) {
                             if (common.value === undefined && objects[id].common[common.attr] !== undefined) continue;
                             if (objects[id].common[common.attr] == common.value) continue;
@@ -483,8 +479,8 @@ function sandBox(script, name, verbose, debug, context) {
 
                     for (const native of nativeSelectors) {
                         if (native.attr === 'id') {
-                            if (!native.r && native.value) native.r = new RegExp(native.value.replace(/\./g, '\\.').replace(/\*/g, '.*'));
-                            if (!native.r || native.r.test(id)) continue;
+                            if (!native.idRegExp && native.value) native.idRegExp = new RegExp(native.value.replace(/\./g, '\\.').replace(/\*/g, '.*'));
+                            if (!native.idRegExp || native.idRegExp.test(id)) continue;
                         } else if (objects[id] && objects[id].native) {
                             if (native.value === undefined && objects[id].native[native.attr] !== undefined) continue;
                             if (objects[id].native[native.attr] == native.value) continue;
@@ -493,21 +489,21 @@ function sandBox(script, name, verbose, debug, context) {
                     }
 
                     for (const filterState of filterStates) {
-                        if (!filterState.r && filterState.value) {
+                        if (!filterState.idRegExp && filterState.value) {
                             if (filterState.value[0] === '*') {
-                                filterState.r = new RegExp(filterState.value.replace(/\./g, '\\.').replace(/\*/g, '.*') + '$');
+                                filterState.idRegExp = new RegExp(filterState.value.replace(/\./g, '\\.').replace(/\*/g, '.*') + '$');
                             } else if (filterState.value[filterState.value.length - 1] === '*') {
-                                filterState.r = new RegExp('^' + filterState.value.replace(/\./g, '\\.').replace(/\*/g, '.*'));
+                                filterState.idRegExp = new RegExp('^' + filterState.value.replace(/\./g, '\\.').replace(/\*/g, '.*'));
                             } else {
-                                filterState.r = new RegExp(filterState.value.replace(/\./g, '\\.').replace(/\*/g, '.*'));
+                                filterState.idRegExp = new RegExp(filterState.value.replace(/\./g, '\\.').replace(/\*/g, '.*'));
                             }
                         }
-                        if (!filterState.r || filterState.r.test(id)) continue;
+                        if (!filterState.idRegExp || filterState.idRegExp.test(id)) continue;
                         continue stateLoop;
                     }
 
                     if (enumSelectors.length) {
-                        let enumIds = [];
+                        const enumIds = [];
                         eventObj.getObjectEnumsSync(context, id, enumIds);
 
                         for (const _enum of enumSelectors) {
@@ -1380,8 +1376,8 @@ function sandBox(script, name, verbose, debug, context) {
                     adapter.log.warn('Object "' + id + '" does not exist');
                     return null;
                 } else if (enumName) {
-                    let e = eventObj.getObjectEnumsSync(context, id);
-                    let obj = JSON.parse(JSON.stringify(objects[id]));
+                    const e = eventObj.getObjectEnumsSync(context, id);
+                    const obj = JSON.parse(JSON.stringify(objects[id]));
                     obj.enumIds   = JSON.parse(JSON.stringify(e.enumIds));
                     obj.enumNames = JSON.parse(JSON.stringify(e.enumNames));
                     if (typeof enumName === 'string') {

--- a/lib/sandbox.js
+++ b/lib/sandbox.js
@@ -446,12 +446,6 @@ function sandBox(script, name, verbose, debug, context) {
             /** @type {string[]} */
             let res = [];
 
-            sandbox.log(`commonSelectors = ${JSON.stringify(commonSelectors)}`);
-            sandbox.log(`nativeSelectors = ${JSON.stringify(nativeSelectors)}`);
-            sandbox.log(`enumSelectors = ${JSON.stringify(enumSelectors)}`);
-            sandbox.log(`objectIdSelectors = ${JSON.stringify(objectIdSelectors)}`);
-            sandbox.log(`stateIdSelectors = ${JSON.stringify(stateIdSelectors)}`);
-
             if (name === 'channel') {
                 // go through all channels
                 res = Object.keys(context.channels)

--- a/lib/sandbox.js
+++ b/lib/sandbox.js
@@ -352,7 +352,8 @@ function sandBox(script, name, verbose, debug, context) {
             let pass;
             if (name === 'channel') {
                 for (const id in context.channels) {
-                    if (!context.channels.hasOwnProperty(id) || !objects.hasOwnProperty(id)) continue;
+                    if (!context.channels.hasOwnProperty(id) || context.channels[id] == null) continue;
+                    if (!objects.hasOwnProperty(id) || objects[id] == null) continue;
                     pass = true;
                     for (let c = 0; c < commons.length; c++) {
                         if (!commons[c]) continue;
@@ -419,10 +420,8 @@ function sandBox(script, name, verbose, debug, context) {
                 }
             } else if (name === 'device') {
                 for (const id in context.devices) {
-                    if (!context.devices.hasOwnProperty(id) || !objects[id]) {
-                        console.log(id);
-                        continue;
-                    }
+                    if (!context.devices.hasOwnProperty(id) || context.devices[id] == null) continue;
+                    if (!objects.hasOwnProperty(id) || objects[id] == null) continue;
                     pass = true;
                     for (let _c = 0; _c < commons.length; _c++) {
                         if (!commons[_c]) continue;
@@ -495,6 +494,8 @@ function sandBox(script, name, verbose, debug, context) {
                 // state
                 for (let s = 0; s < context.stateIds.length; s++) {
                     const id = context.stateIds[s];
+                    if (!context.stateIds.hasOwnProperty(id) || context.stateIds[id] == null) continue;
+                    if (!objects.hasOwnProperty(id) || objects[id] == null) continue;
                     if (r && !r.test(id)) continue;
                     pass = true;
 

--- a/lib/sandbox.js
+++ b/lib/sandbox.js
@@ -18,6 +18,16 @@
 //     isEnums
 // };
 
+/** 
+ * @typedef {Object} SandboxContext
+ * @property {Record<string, string[]>} channels
+ * @property {Record<string, string[]>} devices
+ * @property {string[]} stateIds
+ */
+
+/**
+ * @param {{[prop: string]: any} & SandboxContext} context
+ */
 function sandBox(script, name, verbose, debug, context) {
     const consts   = require(__dirname + '/consts');
     const words    = require(__dirname + '/words');
@@ -137,16 +147,37 @@ function sandBox(script, name, verbose, debug, context) {
     }
 
     /**
+     * Transforms a selector string with wildcards into a regular expression
+     * @param {string} str The selector string to transform into a regular expression
+     */
+    function selectorStringToRegExp(str) {
+        if (str[0] === '*') {
+            // wildcard at the start, match the end of the string
+            return new RegExp(str.replace(/\./g, '\\.').replace(/\*/g, '.*') + '$');
+        } else if (str[str.length - 1] === '*') {
+            // wildcard at the end, match the start of the string
+            return new RegExp('^' + str.replace(/\./g, '\\.').replace(/\*/g, '.*'));
+        } else {
+            // wildcard potentially in the middle, match whatever
+            return new RegExp(str.replace(/\./g, '\\.').replace(/\*/g, '.*'));
+        }
+
+    }
+
+    /**
      * Adds a regular expression for selectors targeting the state ID
      * @param {Selector} selector The selector to apply the transform to
      * @returns {Selector}
      */
     function addRegExpToIdAttrSelectors(selector) {
-        if (!selector.idRegExp && selector.value) {
+        if (
+            (selector.attr === 'id' || selector.attr === 'state.id')
+            && (!selector.idRegExp && selector.value)
+        ) {
             return {
                 attr: selector.attr,
                 value: selector.value,
-                idRegExp: new RegExp('^' + selector.value.replace(/\./g, '\\.').replace(/\*/g, '.*') + '$')
+                idRegExp: selectorStringToRegExp(selector.value)
             };
         } else {
             return selector;
@@ -297,32 +328,34 @@ function sandBox(script, name, verbose, debug, context) {
             }
 
             /** @type {Selector[]} */
-            let commonSelectors = commonStrings
-                .map(selector => splitSelectorString(selector))
-                .map(selector => addRegExpToIdAttrSelectors(selector))
-                ;
-            let nativeSelectors = nativeStrings
-                .map(selector => splitSelectorString(selector))
-                .map(selector => addRegExpToIdAttrSelectors(selector))
-                ;
+            let commonSelectors = commonStrings.map(selector => splitSelectorString(selector));
+            let nativeSelectors = nativeStrings.map(selector => splitSelectorString(selector));
             const enumSelectorObjects = enumStrings.map(_enum => splitSelectorString(_enum));
+            const allSelectors = commonSelectors.concat(nativeSelectors, enumSelectorObjects);
 
-            // All selectors with attr 'state.id' belong into filter states
-            // So filter them out the other selector arrays
-            const filterStates = commonSelectors.concat(nativeSelectors, enumSelectorObjects)
+            // These selectors match the state or object ID and don't belong in the common/native selectors
+            // Also use RegExp for the ID matching
+            const stateIdSelectors = allSelectors
                 .filter(selector => selector.attr === 'state.id')
-            ;
-            commonSelectors = commonSelectors.filter(selector => selector.attr !== 'state.id');
-            nativeSelectors = nativeSelectors.filter(selector => selector.attr !== 'state.id');
+                .map(selector => addRegExpToIdAttrSelectors(selector))
+                ;
+            const objectIdSelectors = allSelectors
+                .filter(selector => selector.attr === 'id')
+                .map(selector => addRegExpToIdAttrSelectors(selector))
+                ;
+
+            commonSelectors = commonSelectors.filter(selector => selector.attr !== 'state.id' && selector.attr !== 'id');
+            nativeSelectors = nativeSelectors.filter(selector => selector.attr !== 'state.id' && selector.attr !== 'id');
             const enumSelectors = enumSelectorObjects
-                .filter(selector => selector.attr !== 'state.id')
+                .filter(selector => selector.attr !== 'state.id' && selector.attr !== 'id')
                 // enums are filtered by their enum id, so transform the selector into that
                 .map(selector => `enum.${selector.attr}.${selector.value}`)
             ;
 
             name = name.trim();
             if (name === 'channel' || name === 'device') {
-                // Fill the channels and devices objects to loop over them afterwards
+                // Fill the channels and devices objects with the IDs of all their states
+                // so we can loop over them afterwards
                 if (!context.channels || !context.devices) {
                     context.channels = {};
                     context.devices  = {};
@@ -345,177 +378,138 @@ function sandBox(script, name, verbose, debug, context) {
                 }
             }
 
-            const res = [];
+            /** 
+             * applies all selectors targeting an object or state ID
+             * @param {string} objId
+             * @param {Selector[]} selectors
+             */
+            function applyIDSelectors(objId, selectors) {
+                // Only keep the ID if it matches every ID selector
+                selectors.every(selector => {
+                    return selector.idRegExp == null || selector.idRegExp.test(objId);
+                });
+            }
+
+            /** 
+             * applies all selectors targeting the Object common properties
+             * @param {string[]} IDs
+             */
+            function applyCommonSelectors(IDs) {
+                // Only keep the IDs that match every common selector
+                return IDs.filter(id => {
+                    if (objects[id] == null || objects[id].common == null) return false;
+                    const objCommon = objects[id].common;
+                    return commonSelectors.every(selector => {
+                        return (
+                            // match existing properties
+                            (selector.value === undefined && objCommon[selector.attr] !== undefined)
+                            // match exact values
+                            || (objCommon[selector.attr] == selector.value)
+                        );
+                    });
+                });
+            }
+
+            /** 
+             * applies all selectors targeting the Object native properties
+             * @param {string[]} IDs
+             */
+            function applyNativeSelectors(IDs) {
+                // Only keep the IDs that match every native selector
+                return IDs.filter(id => {
+                    if (objects[id] == null || objects[id].native == null) return false;
+                    const objNative = objects[id].native;
+                    return nativeSelectors.every(selector => {
+                        return (
+                            // match existing properties
+                            (selector.value === undefined && objNative[selector.attr] !== undefined)
+                            // match exact values
+                            || (objNative[selector.attr] == selector.value)
+                        );
+                    });
+                });
+            }
+
+            /** 
+             * applies all selectors targeting the Objects enums
+             * @param {string[]} IDs
+             */
+            function applyEnumSelectors(IDs) {
+                // Only keep the IDs which are in all enums requested by the selectors
+                return IDs.filter(id => {
+                    const enumIds = [];
+                    eventObj.getObjectEnumsSync(context, id, enumIds);
+                    return enumSelectors.every(_enum => enumIds.indexOf(_enum) > -1);
+                });
+            }
+
+            /** @type {string[]} */
+            let res = [];
+
+            sandbox.log(`commonSelectors = ${JSON.stringify(commonSelectors)}`);
+            sandbox.log(`nativeSelectors = ${JSON.stringify(nativeSelectors)}`);
+            sandbox.log(`enumSelectors = ${JSON.stringify(enumSelectors)}`);
+            sandbox.log(`objectIdSelectors = ${JSON.stringify(objectIdSelectors)}`);
+            sandbox.log(`stateIdSelectors = ${JSON.stringify(stateIdSelectors)}`);
+
             if (name === 'channel') {
-                channelLoop: for (const id in context.channels) {
-                    if (!context.channels.hasOwnProperty(id) || context.channels[id] == null) continue;
+                // go through all channels
+                res = Object.keys(context.channels)
+                    // filter out those that don't match every ID selector for the channel ID
+                    .filter(channelId => applyIDSelectors(channelId, objectIdSelectors))
+                    // retrieve the state ID collection for all remaining channels
+                    .map(id => context.channels[id])
+                    // filter out those that don't match every common selector
+                    .filter(stateIDs => applyCommonSelectors(stateIDs))
+                    // filter out those that don't match every native selector
+                    .filter(stateIDs => applyNativeSelectors(stateIDs))
+                    // filter out those that don't match every enum selector
+                    .filter(stateIDs => applyEnumSelectors(stateIDs))
+                    // flatten the remaining array to get only the state IDs
+                    .reduce((acc, next) => acc.concat(next), [])
+                    // now filter out those that don't match every ID selector for the state ID
+                    .filter(stateIDs => applyIDSelectors(stateIDs, stateIdSelectors))
+                ;
 
-                    for (const common of commonSelectors) {
-                        if (common.attr === 'id') {
-                            if (!common.idRegExp && common.value) common.idRegExp = new RegExp('^' + common.value.replace(/\./g, '\\.').replace(/\*/g, '.*') + '$');
-                            if (!common.idRegExp || common.idRegExp.test(id)) continue;
-                        } else if (objects[id] && objects[id].common) {
-                            if (common.value === undefined && objects[id].common[common.attr] !== undefined) continue;
-                            if (objects[id].common[common.attr] === common.value) continue;
-                        }
-                        continue channelLoop;
-                    }
-
-                    for (const native of nativeSelectors) {
-                        if (!native) continue;
-                        if (native.attr === 'id') {
-                            if (!native.idRegExp && native.value) native.idRegExp = new RegExp('^' + native.value.replace(/\./g, '\\.').replace(/\*/g, '.*') + '$');
-                            if (!native.idRegExp || native.idRegExp.test(id)) continue;
-                        } else if (objects[id] && objects[id].native) {
-                            if (native.value === undefined && objects[id].native[native.attr] !== undefined) continue;
-                            if (objects[id].native[native.attr] == native.value) continue;
-                        }
-                        continue channelLoop;
-                    }
-
-                    if (enumSelectors.length) {
-                        const enumIds = [];
-                        eventObj.getObjectEnumsSync(context, id, enumIds);
-
-                        for (const _enum of enumSelectors) {
-                            if (enumIds.indexOf(_enum) !== -1) continue;
-                            continue channelLoop;
-                        }
-                    }
-
-                    // Add all states of this channel to list
-                    for (const channel of context.channels[id]) {
-                        if (filterStates.length) {
-                            for (const filterState of filterStates) {
-                                if (!filterState.idRegExp && filterState.value) {
-                                    if (filterState.value[0] === '*') {
-                                        filterState.idRegExp = new RegExp(filterState.value.replace(/\./g, '\\.').replace(/\*/g, '.*') + '$');
-                                    } else if (filterState.value[filterState.value.length - 1] === '*') {
-                                        filterState.idRegExp = new RegExp('^' + filterState.value.replace(/\./g, '\\.').replace(/\*/g, '.*'));
-                                    } else {
-                                        filterState.idRegExp = new RegExp(filterState.value.replace(/\./g, '\\.').replace(/\*/g, '.*'));
-                                    }
-                                }
-                                if (!filterState.idRegExp || filterState.idRegExp.test(channel)) continue;
-                                continue channelLoop;
-                            }
-                        }
-                        res.push(channel);
-                    }
-                }
             } else if (name === 'device') {
-                deviceLoop: for (const id in context.devices) {
-                    if (!context.devices.hasOwnProperty(id) || context.devices[id] == null) continue;
+                // go through all devices
+                res = Object.keys(context.devices)
+                    // filter out those that don't match every ID selector for the channel ID
+                    .filter(deviceId => applyIDSelectors(deviceId, objectIdSelectors))
+                    // retrieve the state ID collection for all remaining devices
+                    .map(id => context.devices[id])
+                    // filter out those that don't match every common selector
+                    .filter(stateIDs => applyCommonSelectors(stateIDs))
+                    // filter out those that don't match every native selector
+                    .filter(stateIDs => applyNativeSelectors(stateIDs))
+                    // filter out those that don't match every enum selector
+                    .filter(stateIDs => applyEnumSelectors(stateIDs))
+                    // flatten the remaining array to get only the state IDs
+                    .reduce((acc, next) => acc.concat(next), [])
+                    // now filter out those that don't match every ID selector for the state ID
+                    .filter(stateIDs => applyIDSelectors(stateIDs, stateIdSelectors))
+                ;
 
-                    for (const common of commonSelectors) {
-                        if (common.attr === 'id') {
-                            if (!common.idRegExp && common.value) common.idRegExp = new RegExp('^' + common.value.replace(/\./g, '\\.').replace(/\*/g, '.*') + '$');
-                            if (!common.idRegExp || common.idRegExp.test(id)) continue;
-                        } else if (objects[id] && objects[id].common) {
-                            if (common.value === undefined && objects[id].common[common.attr] !== undefined) continue;
-                            if (objects[id].common[common.attr] == common.value) continue;
-                        }
-                        continue deviceLoop;
-                    }
-
-                    for (const native of nativeSelectors) {
-                        if (native.attr === 'id') {
-                            if (!native.idRegExp && native.value) native.idRegExp = new RegExp('^' + native.value.replace(/\./g, '\\.').replace(/\*/g, '.*') + '$');
-                            if (!native.idRegExp || native.idRegExp.test(id)) continue;
-                        } else if (objects[id] && objects[id].native) {
-                            if (native.value === undefined && objects[id].native[native.attr] !== undefined) continue;
-                            if (objects[id].native[native.attr] == native.value) continue;
-                        }
-                        continue deviceLoop;
-                    }
-
-                    if (enumSelectors.length) {
-                        const enumIds = [];
-                        eventObj.getObjectEnumsSync(context, id, enumIds);
-
-                        for (const _enum of enumSelectors) {
-                            if (enumIds.indexOf(_enum) !== -1) continue;
-                            continue deviceLoop;
-                        }
-                    }
-
-                    // Add all states of this channel to list
-                    for (const device of context.devices[id]) {
-                        if (filterStates.length) {
-                            for (const filterState of filterStates) {
-                                if (!filterState.idRegExp && filterState.value) {
-                                    if (filterState.value[0] === '*') {
-                                        filterState.idRegExp = new RegExp(filterState.value.replace(/\./g, '\\.').replace(/\*/g, '.*') + '$');
-                                    } else if (filterState.value[filterState.value.length - 1] === '*') {
-                                        filterState.idRegExp = new RegExp('^' + filterState.value.replace(/\./g, '\\.').replace(/\*/g, '.*'));
-                                    } else {
-                                        filterState.idRegExp = new RegExp(filterState.value.replace(/\./g, '\\.').replace(/\*/g, '.*'));
-                                    }
-                                }
-                                if (!filterState.idRegExp || filterState.idRegExp.test(device)) continue;
-                                continue deviceLoop;
-                            }
-                        }
-                        res.push(device);
-                    }
-                }
             } else {
-                const r = (name && name !== 'state') ? new RegExp('^' + name.replace(/\./g, '\\.').replace(/\*/g, '.*') + '$') : null;
-
-                // state
-                stateLoop: for (const id of context.stateIds) {
-                    if (r && !r.test(id)) continue;
-
-                    for (const common of commonSelectors) {
-                        if (common.attr === 'id') {
-                            if (!common.idRegExp && common.value) common.idRegExp = new RegExp(common.value.replace(/\./g, '\\.').replace(/\*/g, '.*'));
-                            if (!common.idRegExp || common.idRegExp.test(id)) continue;
-                        } else if (objects[id] && objects[id].common) {
-                            if (common.value === undefined && objects[id].common[common.attr] !== undefined) continue;
-                            if (objects[id].common[common.attr] == common.value) continue;
-                        }
-                        continue stateLoop;
-                    }
-
-                    for (const native of nativeSelectors) {
-                        if (native.attr === 'id') {
-                            if (!native.idRegExp && native.value) native.idRegExp = new RegExp(native.value.replace(/\./g, '\\.').replace(/\*/g, '.*'));
-                            if (!native.idRegExp || native.idRegExp.test(id)) continue;
-                        } else if (objects[id] && objects[id].native) {
-                            if (native.value === undefined && objects[id].native[native.attr] !== undefined) continue;
-                            if (objects[id].native[native.attr] == native.value) continue;
-                        }
-                        continue stateLoop;
-                    }
-
-                    for (const filterState of filterStates) {
-                        if (!filterState.idRegExp && filterState.value) {
-                            if (filterState.value[0] === '*') {
-                                filterState.idRegExp = new RegExp(filterState.value.replace(/\./g, '\\.').replace(/\*/g, '.*') + '$');
-                            } else if (filterState.value[filterState.value.length - 1] === '*') {
-                                filterState.idRegExp = new RegExp('^' + filterState.value.replace(/\./g, '\\.').replace(/\*/g, '.*'));
-                            } else {
-                                filterState.idRegExp = new RegExp(filterState.value.replace(/\./g, '\\.').replace(/\*/g, '.*'));
-                            }
-                        }
-                        if (!filterState.idRegExp || filterState.idRegExp.test(id)) continue;
-                        continue stateLoop;
-                    }
-
-                    if (enumSelectors.length) {
-                        const enumIds = [];
-                        eventObj.getObjectEnumsSync(context, id, enumIds);
-
-                        for (const _enum of enumSelectors) {
-                            if (enumIds.indexOf(_enum) !== -1) continue;
-                            continue stateLoop;
-                        }
-                    }
-                    // Add all states of this channel to list
-                    res.push(id);
+                // go through all states
+                res = context.stateIds;
+                // if the "name" is not state then we filter for the ID aswell
+                if (name && name !== 'state') {
+                    const r = new RegExp('^' + name.replace(/\./g, '\\.').replace(/\*/g, '.*') + '$');
+                    res = res.filter(id => r.test(id));
                 }
 
-                // Now filter away by name
+                // filter out those that don't match every ID selector for the object ID or the state ID
+                res = res
+                    .filter(id => applyIDSelectors(id, objectIdSelectors))
+                    .filter(id => applyIDSelectors(id, stateIdSelectors))
+                ;
+                // filter out those that don't match every common selector
+                res = applyCommonSelectors(res);
+                // filter out those that don't match every native selector
+                res = applyNativeSelectors(res);
+                // filter out those that don't match every enum selector
+                res = applyEnumSelectors(res);
             }
 
             for (let i = 0; i < res.length; i++) {

--- a/lib/sandbox.js
+++ b/lib/sandbox.js
@@ -160,69 +160,72 @@ function sandBox(script, name, verbose, debug, context) {
             const result  = {};
 
             let name      = '';
-            const commons = [];
-            const _enums  = [];
-            const natives = [];
-            let isName    = true;
-            let isCommons = false;
-            let isEnums   = false;
-            let isNatives = false;
-            let common    = '';
-            let native    = '';
-            let _enum     = '';
-            let parts;
-            let len;
+            /** @type {string[]} */
+            const commonStrings = [];
+            /** @type {string[]} */
+            const enumStrings  = [];
+            /** @type {string[]} */
+            const nativeStrings = [];
+            let isInsideName    = true;
+            let isInsideCommonString = false;
+            let isInsideEnumString   = false;
+            let isInsideNativeString = false;
+            let currentCommonString    = '';
+            let currentNativeString    = '';
+            let currentEnumString     = '';
+            // let parts;
+            // let len;
 
             // parse string
             for (let i = 0; i < selector.length; i++) {
                 if (selector[i] === '{') {
-                    isName = false;
-                    if (isCommons || isEnums || isNatives) {
+                    isInsideName = false;
+                    if (isInsideCommonString || isInsideEnumString || isInsideNativeString) {
                         // Error
                         return [];
                     }
-                    isNatives = true;
+                    isInsideNativeString = true;
                 } else if (selector[i] === '}') {
-                    isNatives = false;
-                    natives.push(native);
-                    native = '';
+                    isInsideNativeString = false;
+                    nativeStrings.push(currentNativeString);
+                    currentNativeString = '';
                 } else if (selector[i] === '[') {
-                    isName = false;
-                    if (isCommons || isEnums || isNatives) {
+                    isInsideName = false;
+                    if (isInsideCommonString || isInsideEnumString || isInsideNativeString) {
                         // Error
                         return [];
                     }
-                    isCommons = true;
+                    isInsideCommonString = true;
                 } else if (selector[i] === ']') {
-                    isCommons = false;
-                    commons.push(common);
-                    common = '';
+                    isInsideCommonString = false;
+                    commonStrings.push(currentCommonString);
+                    currentCommonString = '';
                 } else if (selector[i] === '(') {
-                    isName = false;
-                    if (isCommons || isEnums || isNatives) {
+                    isInsideName = false;
+                    if (isInsideCommonString || isInsideEnumString || isInsideNativeString) {
                         // Error
                         return [];
                     }
-                    isEnums = true;
+                    isInsideEnumString = true;
                 } else if (selector[i] === ')') {
-                    isEnums = false;
-                    _enums.push(_enum);
-                    _enum = '';
-                } else if (isName) {
+                    isInsideEnumString = false;
+                    enumStrings.push(currentEnumString);
+                    currentEnumString = '';
+                } else if (isInsideName) {
                     name += selector[i];
-                } else if (isCommons) {
-                    common += selector[i];
-                } else if (isEnums) {
-                    _enum += selector[i];
-                } else if (isNatives) {
-                    native += selector[i];
+                } else if (isInsideCommonString) {
+                    currentCommonString += selector[i];
+                } else if (isInsideEnumString) {
+                    currentEnumString += selector[i];
+                } else if (isInsideNativeString) {
+                    currentNativeString += selector[i];
                 } //else {
                 // some error
                 //}
             }
 
             // If some error in the selector
-            if (isEnums || isCommons || isNatives) {
+            if (isInsideEnumString || isInsideCommonString || isInsideNativeString) {
                 result.length = 0;
                 result.each = function () {
                     return this;
@@ -237,91 +240,85 @@ function sandBox(script, name, verbose, debug, context) {
                 };
             }
 
-            if (isEnums) {
+            if (isInsideEnumString) {
                 adapter.log.warn('Invalid selector: enum close bracket cannot be found in "' + selector + '"');
                 result.error = 'Invalid selector: enum close bracket cannot be found';
                 return result;
-            } else if (isCommons) {
+            } else if (isInsideCommonString) {
                 adapter.log.warn('Invalid selector: common close bracket cannot be found in "' + selector + '"');
                 result.error = 'Invalid selector: common close bracket cannot be found';
                 return result;
-            } else if (isNatives) {
+            } else if (isInsideNativeString) {
                 adapter.log.warn('Invalid selector: native close bracket cannot be found in "' + selector + '"');
                 result.error = 'Invalid selector: native close bracket cannot be found';
                 return result;
             }
 
+            /** @typedef {{attr: string, value: string, r?: RegExp}} Selector */
+            /**
+             * Splits a selector string into attribute and value
+             * @param {string} selector The selector string to split
+             * @returns {Selector}
+             */
+            function splitSelectorString(selector) {
+                const parts = selector.split('=', 2);
+                if (parts[1] && parts[1][0] === '"') {
+                    parts[1] = parts[1].substring(1);
+                    const len = parts[1].length;
+                    if (parts[1] && parts[1][len - 1] === '"') parts[1] = parts[1].substring(0, len - 1);
+                }
+                if (parts[1] && parts[1][0] === "'") {
+                    parts[1] = parts[1].substring(1);
+                    const len = parts[1].length;
+                    if (parts[1] && parts[1][len - 1] === "'") parts[1] = parts[1].substring(0, len - 1);
+                }
+
+                if (parts[1]) parts[1] = parts[1].trim();
+                parts[0] = parts[0].trim();
+
+                return {attr: parts[0], value: parts[1]};
+            }
+
+            /** @type {Selector[]} */
             const filterStates = [];
+            const commonSelectors = commonStrings
+                .map(common => {
+                    const ret = splitSelectorString(common);
+                    if (ret.attr === 'state.id') {
+                        filterStates.push(ret);
+                        return null;
+                    } else {
+                        return ret;
+                    }
+                })
+                .filter(common => common != null)
+            ;
 
-            for (let i = 0; i < commons.length; i++) {
-                parts = commons[i].split('=', 2);
-                if (parts[1] && parts[1][0] === '"') {
-                    parts[1] = parts[1].substring(1);
-                    len = parts[1].length;
-                    if (parts[1] && parts[1][len - 1] === '"') parts[1] = parts[1].substring(0, len - 1);
-                }
-                if (parts[1] && parts[1][0] === "'") {
-                    parts[1] = parts[1].substring(1);
-                    len = parts[1].length;
-                    if (parts[1] && parts[1][len - 1] === "'") parts[1] = parts[1].substring(0, len - 1);
-                }
+            const nativeSelectors = nativeStrings
+                .map(native => {
+                    const ret = splitSelectorString(native);
+                    if (ret.attr === 'state.id') {
+                        filterStates.push(ret);
+                        return null;
+                    } else {
+                        return ret;
+                    }
+                })
+                .filter(native => native != null)
+            ;
 
-                if (parts[1]) parts[1] = parts[1].trim();
-                parts[0] = parts[0].trim();
-
-                if (parts[0] === 'state.id') {
-                    filterStates.push({attr: parts[0], value: parts[1].trim()});
-                    commons[i] = null;
-                } else {
-                    commons[i] = {attr: parts[0], value: parts[1].trim()};
-                }
-            }
-
-            for (let i = 0; i < natives.length; i++) {
-                parts = natives[i].split('=', 2);
-                if (parts[1] && parts[1][0] === '"') {
-                    parts[1] = parts[1].substring(1);
-                    len = parts[1].length;
-                    if (parts[1] && parts[1][len - 1] === '"') parts[1] = parts[1].substring(0, len - 1);
-                }
-                if (parts[1] && parts[1][0] === "'") {
-                    parts[1] = parts[1].substring(1);
-                    len = parts[1].length;
-                    if (parts[1] && parts[1][len - 1] === "'") parts[1] = parts[1].substring(0, len - 1);
-                }
-
-                if (parts[1]) parts[1] = parts[1].trim();
-                parts[0] = parts[0].trim();
-                if (parts[0] === 'state.id') {
-                    filterStates.push({attr: parts[0], value: parts[1].trim()});
-                    natives[i] = null;
-                } else {
-                    natives[i] = {attr: parts[0].trim(), value: parts[1].trim()};
-                }
-            }
-
-            for (let i = 0; i < _enums.length; i++) {
-                parts = _enums[i].split('=', 2);
-                if (parts[1] && parts[1][0] === '"') {
-                    parts[1] = parts[1].substring(1);
-                    len = parts[1].length;
-                    if (parts[1] && parts[1][len - 1] === '"') parts[1] = parts[1].substring(0, len - 1);
-                }
-                if (parts[1] && parts[1][0] === "'") {
-                    parts[1] = parts[1].substring(1);
-                    len = parts[1].length;
-                    if (parts[1] && parts[1][len - 1] === "'") parts[1] = parts[1].substring(0, len - 1);
-                }
-
-                if (parts[1]) parts[1] = parts[1].trim();
-                parts[0] = parts[0].trim();
-                if (parts[0] === 'state.id') {
-                    filterStates.push({attr: parts[0], value: parts[1].trim()});
-                    _enums[i] = null;
-                } else {
-                    _enums[i] = 'enum.' + parts[0].trim() + '.' + parts[1].trim();
-                }
-            }
+            const enumSelectors = enumStrings
+                .map(_enum => {
+                    const ret = splitSelectorString(_enum);
+                    if (ret.attr === 'state.id') {
+                        filterStates.push(ret);
+                        return null;
+                    } else {
+                        return `enum.${ret.attr}.${ret.value}`;
+                    }
+                })
+                .filter(_enum => _enum != null)
+            ;
 
             name = name.trim();
             if (name === 'channel' || name === 'device') {
@@ -331,7 +328,7 @@ function sandBox(script, name, verbose, debug, context) {
                     context.devices  = {};
                     for (const _id in objects) {
                         if (objects.hasOwnProperty(_id) && objects[_id].type === 'state') {
-                            parts = _id.split('.');
+                            const parts = _id.split('.');
                             parts.pop();
                             const chn = parts.join('.');
 
@@ -349,216 +346,174 @@ function sandBox(script, name, verbose, debug, context) {
             }
 
             const res = [];
-            let pass;
             if (name === 'channel') {
-                for (const id in context.channels) {
+                channelLoop: for (const id in context.channels) {
                     if (!context.channels.hasOwnProperty(id) || context.channels[id] == null) continue;
                     if (!objects.hasOwnProperty(id) || objects[id] == null) continue;
-                    pass = true;
-                    for (let c = 0; c < commons.length; c++) {
-                        if (!commons[c]) continue;
-                        if (commons[c].attr === 'id') {
-                            if (!commons[c].r && commons[c].value) commons[c].r = new RegExp('^' + commons[c].value.replace(/\./g, '\\.').replace(/\*/g, '.*') + '$');
-                            if (!commons[c].r || commons[c].r.test(id)) continue;
-                        } else if (objects[id].common) {
-                            if (commons[c].value === undefined && objects[id].common[commons[c].attr] !== undefined) continue;
-                            if (objects[id].common[commons[c].attr] === commons[c].value) continue;
-                        }
-                        pass = false;
-                        break;
-                    }
-                    if (!pass) continue;
-                    for (let n = 0; n < natives.length; n++) {
-                        if (!natives[n]) continue;
-                        if (natives[n].attr === 'id') {
-                            if (!natives[n].r && natives[n].value) natives[n].r = new RegExp('^' + natives[n].value.replace(/\./g, '\\.').replace(/\*/g, '.*') + '$');
-                            if (!natives[n].r || natives[n].r.test(id)) continue;
-                        } else if (objects[id].native) {
-                            if (natives[n].value === undefined && objects[id].native[natives[n].attr] !== undefined) continue;
-                            if (objects[id].native[natives[n].attr] == natives[n].value) continue;
-                        }
-                        pass = false;
-                        break;
-                    }
-                    if (!pass) continue;
 
-                    if (_enums.length) {
+                    for (const common of commonSelectors) {
+                        if (common.attr === 'id') {
+                            if (!common.r && common.value) common.r = new RegExp('^' + common.value.replace(/\./g, '\\.').replace(/\*/g, '.*') + '$');
+                            if (!common.r || common.r.test(id)) continue;
+                        } else if (objects[id].common) {
+                            if (common.value === undefined && objects[id].common[common.attr] !== undefined) continue;
+                            if (objects[id].common[common.attr] === common.value) continue;
+                        }
+                        continue channelLoop;
+                    }
+
+                    for (const native of nativeSelectors) {
+                        if (!native) continue;
+                        if (native.attr === 'id') {
+                            if (!native.r && native.value) native.r = new RegExp('^' + native.value.replace(/\./g, '\\.').replace(/\*/g, '.*') + '$');
+                            if (!native.r || native.r.test(id)) continue;
+                        } else if (objects[id].native) {
+                            if (native.value === undefined && objects[id].native[native.attr] !== undefined) continue;
+                            if (objects[id].native[native.attr] == native.value) continue;
+                        }
+                        continue channelLoop;
+                    }
+
+                    if (enumSelectors.length) {
                         let enumIds = [];
                         eventObj.getObjectEnumsSync(context, id, enumIds);
 
-                        for (let m = 0; m < _enums.length; m++) {
-                            if (!_enums[m]) continue;
-                            if (enumIds.indexOf(_enums[m]) !== -1) continue;
-                            pass = false;
-                            break;
+                        for (const _enum of enumSelectors) {
+                            if (enumIds.indexOf(_enum) !== -1) continue;
+                            continue channelLoop;
                         }
-                        if (!pass) continue;
                     }
 
                     // Add all states of this channel to list
-                    for (let s = 0; s < context.channels[id].length; s++) {
+                    for (const channel of context.channels[id]) {
                         if (filterStates.length) {
-                            pass = true;
-                            for (let st = 0; st < filterStates.length; st++) {
-                                if (!filterStates[st].r && filterStates[st].value) {
-                                    if (filterStates[st].value[0] === '*') {
-                                        filterStates[st].r = new RegExp(filterStates[st].value.replace(/\./g, '\\.').replace(/\*/g, '.*') + '$');
-                                    } else if (filterStates[st].value[filterStates[st].value - 1] === '*') {
-                                        filterStates[st].r = new RegExp('^' + filterStates[st].value.replace(/\./g, '\\.').replace(/\*/g, '.*'));
+                            for (const filterState of filterStates) {
+                                if (!filterState.r && filterState.value) {
+                                    if (filterState.value[0] === '*') {
+                                        filterState.r = new RegExp(filterState.value.replace(/\./g, '\\.').replace(/\*/g, '.*') + '$');
+                                    } else if (filterState.value[filterState.value.length - 1] === '*') {
+                                        filterState.r = new RegExp('^' + filterState.value.replace(/\./g, '\\.').replace(/\*/g, '.*'));
                                     } else {
-                                        filterStates[st].r = new RegExp(filterStates[st].value.replace(/\./g, '\\.').replace(/\*/g, '.*'));
+                                        filterState.r = new RegExp(filterState.value.replace(/\./g, '\\.').replace(/\*/g, '.*'));
                                     }
                                 }
-                                if (!filterStates[st].r || filterStates[st].r.test(context.channels[id][s])) continue;
-                                pass = false;
-                                break;
+                                if (!filterState.r || filterState.r.test(channel)) continue;
+                                continue channelLoop;
                             }
-                            if (!pass) continue;
                         }
-                        res.push(context.channels[id][s]);
+                        res.push(channel);
                     }
                 }
             } else if (name === 'device') {
-                for (const id in context.devices) {
+                deviceLoop: for (const id in context.devices) {
                     if (!context.devices.hasOwnProperty(id) || context.devices[id] == null) continue;
                     if (!objects.hasOwnProperty(id) || objects[id] == null) continue;
-                    pass = true;
-                    for (let _c = 0; _c < commons.length; _c++) {
-                        if (!commons[_c]) continue;
-                        if (commons[_c].attr === 'id') {
-                            if (!commons[_c].r && commons[_c].value) commons[_c].r = new RegExp('^' + commons[_c].value.replace(/\./g, '\\.').replace(/\*/g, '.*') + '$');
-                            if (!commons[_c].r || commons[_c].r.test(id)) continue;
+
+                    for (const common of commonSelectors) {
+                        if (common.attr === 'id') {
+                            if (!common.r && common.value) common.r = new RegExp('^' + common.value.replace(/\./g, '\\.').replace(/\*/g, '.*') + '$');
+                            if (!common.r || common.r.test(id)) continue;
                         } else if (objects[id].common) {
-                            if (commons[_c].value === undefined && objects[id].common[commons[_c].attr] !== undefined) continue;
-                            if (objects[id].common[commons[_c].attr] == commons[_c].value) continue;
+                            if (common.value === undefined && objects[id].common[common.attr] !== undefined) continue;
+                            if (objects[id].common[common.attr] == common.value) continue;
                         }
-                        pass = false;
-                        break;
+                        continue deviceLoop;
                     }
 
-                    if (!pass) continue;
-
-                    for (let n = 0; n < natives.length; n++) {
-                        if (!natives[n]) continue;
-                        if (natives[n].attr === 'id') {
-                            if (!natives[n].r && natives[n].value) natives[n].r = new RegExp('^' + natives[n].value.replace(/\./g, '\\.').replace(/\*/g, '.*') + '$');
-                            if (!natives[n].r || natives[n].r.test(id)) continue;
+                    for (const native of nativeSelectors) {
+                        if (native.attr === 'id') {
+                            if (!native.r && native.value) native.r = new RegExp('^' + native.value.replace(/\./g, '\\.').replace(/\*/g, '.*') + '$');
+                            if (!native.r || native.r.test(id)) continue;
                         } else if (objects[id].native) {
-                            if (natives[n].value === undefined && objects[id].native[natives[n].attr] !== undefined) continue;
-                            if (objects[id].native[natives[n].attr] == natives[n].value) continue;
+                            if (native.value === undefined && objects[id].native[native.attr] !== undefined) continue;
+                            if (objects[id].native[native.attr] == native.value) continue;
                         }
-                        pass = false;
-                        break;
+                        continue deviceLoop;
                     }
-                    if (!pass) continue;
 
-                    if (_enums.length) {
+                    if (enumSelectors.length) {
                         let enumIds = [];
                         eventObj.getObjectEnumsSync(context, id, enumIds);
 
-                        for (let n = 0; n < _enums.length; n++) {
-                            if (!_enums[n]) continue;
-                            if (enumIds.indexOf(_enums[n]) !== -1) continue;
-                            pass = false;
-                            break;
+                        for (const _enum of enumSelectors) {
+                            if (enumIds.indexOf(_enum) !== -1) continue;
+                            continue deviceLoop;
                         }
-                        if (!pass) continue;
                     }
 
                     // Add all states of this channel to list
-                    for (let s = 0; s < context.devices[id].length; s++) {
+                    for (const device of context.devices[id]) {
                         if (filterStates.length) {
-                            pass = true;
-                            for (let st = 0; st < filterStates.length; st++) {
-                                if (!filterStates[st].r && filterStates[st].value) {
-                                    if (filterStates[st].value[0] === '*') {
-                                        filterStates[st].r = new RegExp(filterStates[st].value.replace(/\./g, '\\.').replace(/\*/g, '.*') + '$');
-                                    } else if (filterStates[st].value[filterStates[st].value - 1] === '*') {
-                                        filterStates[st].r = new RegExp('^' + filterStates[st].value.replace(/\./g, '\\.').replace(/\*/g, '.*'));
+                            for (const filterState of filterStates) {
+                                if (!filterState.r && filterState.value) {
+                                    if (filterState.value[0] === '*') {
+                                        filterState.r = new RegExp(filterState.value.replace(/\./g, '\\.').replace(/\*/g, '.*') + '$');
+                                    } else if (filterState.value[filterState.value.length - 1] === '*') {
+                                        filterState.r = new RegExp('^' + filterState.value.replace(/\./g, '\\.').replace(/\*/g, '.*'));
                                     } else {
-                                        filterStates[st].r = new RegExp(filterStates[st].value.replace(/\./g, '\\.').replace(/\*/g, '.*'));
+                                        filterState.r = new RegExp(filterState.value.replace(/\./g, '\\.').replace(/\*/g, '.*'));
                                     }
                                 }
-                                if (!filterStates[st].r || filterStates[st].r.test(context.devices[id][s])) continue;
-                                pass = false;
-                                break;
+                                if (!filterState.r || filterState.r.test(device)) continue;
+                                continue deviceLoop;
                             }
-                            if (!pass) continue;
                         }
-                        res.push(context.devices[id][s]);
+                        res.push(device);
                     }
                 }
             } else {
                 const r = (name && name !== 'state') ? new RegExp('^' + name.replace(/\./g, '\\.').replace(/\*/g, '.*') + '$') : null;
 
                 // state
-                for (let s = 0; s < context.stateIds.length; s++) {
-                    const id = context.stateIds[s];
+                stateLoop: for (const id of context.stateIds) {
                     if (!context.stateIds.hasOwnProperty(id) || context.stateIds[id] == null) continue;
                     if (!objects.hasOwnProperty(id) || objects[id] == null) continue;
                     if (r && !r.test(id)) continue;
-                    pass = true;
 
-                    if (commons.length) {
-                        for (let c = 0; c < commons.length; c++) {
-                            if (!commons[c]) continue;
-                            if (commons[c].attr === 'id') {
-                                if (!commons[c].r && commons[c].value) commons[c].r = new RegExp(commons[c].value.replace(/\./g, '\\.').replace(/\*/g, '.*'));
-                                if (!commons[c].r || commons[c].r.test(id)) continue;
-                            } else if (objects[id] && objects[id].common) {
-                                if (commons[c].value === undefined && objects[id].common[commons[c].attr] !== undefined) continue;
-                                if (objects[id].common[commons[c].attr] == commons[c].value) continue;
-                            }
-                            pass = false;
-                            break;
+                    for (const common of commonSelectors) {
+                        if (common.attr === 'id') {
+                            if (!common.r && common.value) common.r = new RegExp(common.value.replace(/\./g, '\\.').replace(/\*/g, '.*'));
+                            if (!common.r || common.r.test(id)) continue;
+                        } else if (objects[id] && objects[id].common) {
+                            if (common.value === undefined && objects[id].common[common.attr] !== undefined) continue;
+                            if (objects[id].common[common.attr] == common.value) continue;
                         }
-                        if (!pass) continue;
-                    }
-                    if (natives.length) {
-                        for (let n = 0; n < natives.length; n++) {
-                            if (!natives[n]) continue;
-                            if (natives[n].attr === 'id') {
-                                if (!natives[n].r && natives[n].value) natives[id].r = new RegExp(natives[n].value.replace(/\./g, '\\.').replace(/\*/g, '.*'));
-                                if (!natives[n].r || natives[n].r.test(id)) continue;
-                            } else if (objects[id] && objects[id].native) {
-                                if (natives[n].value === undefined && objects[id].native[natives[n].attr] !== undefined) continue;
-                                if (objects[id].native[natives[n].attr] == natives[n].value) continue;
-                            }
-                            pass = false;
-                            break;
-                        }
-                        if (!pass) continue;
+                        continue stateLoop;
                     }
 
-                    if (filterStates.length) {
-                        for (let st = 0; st < filterStates.length; st++) {
-                            if (!filterStates[st].r && filterStates[st].value) {
-                                if (filterStates[st].value[0] === '*') {
-                                    filterStates[st].r = new RegExp(filterStates[st].value.replace(/\./g, '\\.').replace(/\*/g, '.*') + '$');
-                                } else if (filterStates[st].value[filterStates[st].value - 1] === '*') {
-                                    filterStates[st].r = new RegExp('^' + filterStates[st].value.replace(/\./g, '\\.').replace(/\*/g, '.*'));
-                                } else {
-                                    filterStates[st].r = new RegExp(filterStates[st].value.replace(/\./g, '\\.').replace(/\*/g, '.*'));
-                                }
-                            }
-                            if (!filterStates[st].r || filterStates[st].r.test(id)) continue;
-                            pass = false;
-                            break;
+                    for (const native of nativeSelectors) {
+                        if (native.attr === 'id') {
+                            if (!native.r && native.value) native.r = new RegExp(native.value.replace(/\./g, '\\.').replace(/\*/g, '.*'));
+                            if (!native.r || native.r.test(id)) continue;
+                        } else if (objects[id] && objects[id].native) {
+                            if (native.value === undefined && objects[id].native[native.attr] !== undefined) continue;
+                            if (objects[id].native[native.attr] == native.value) continue;
                         }
-                        if (!pass) continue;
+                        continue stateLoop;
                     }
 
-                    if (_enums.length) {
+                    for (const filterState of filterStates) {
+                        if (!filterState.r && filterState.value) {
+                            if (filterState.value[0] === '*') {
+                                filterState.r = new RegExp(filterState.value.replace(/\./g, '\\.').replace(/\*/g, '.*') + '$');
+                            } else if (filterState.value[filterState.value.length - 1] === '*') {
+                                filterState.r = new RegExp('^' + filterState.value.replace(/\./g, '\\.').replace(/\*/g, '.*'));
+                            } else {
+                                filterState.r = new RegExp(filterState.value.replace(/\./g, '\\.').replace(/\*/g, '.*'));
+                            }
+                        }
+                        if (!filterState.r || filterState.r.test(id)) continue;
+                        continue stateLoop;
+                    }
+
+                    if (enumSelectors.length) {
                         let enumIds = [];
                         eventObj.getObjectEnumsSync(context, id, enumIds);
 
-                        for (let nn = 0; nn < _enums.length; nn++) {
-                            if (!_enums[nn]) continue;
-                            if (enumIds.indexOf(_enums[nn]) !== -1) continue;
-                            pass = false;
-                            break;
+                        for (const _enum of enumSelectors) {
+                            if (enumIds.indexOf(_enum) !== -1) continue;
+                            continue stateLoop;
                         }
-                        if (!pass) continue;
                     }
                     // Add all states of this channel to list
                     res.push(id);


### PR DESCRIPTION
Looking at this function has bugged me for a while because it was a huge red block in VSCode where type checking was not working. Hidden inside this red block were a few bugs like 
`filterStates[st].value[filterStates[st].value - 1]` which cannot work since `value` is a string.

What I did here:
* gave the variables at the top a speaking name and some type declarations to find bugs down the line
* Moved the filtering code that was repeated a couple of times into functions with speaking names.
* Replaced almost every loop and filter operation with `filter` and `map` calls on the arrays.
* Used the same regex rules for object and state IDs:
  * `"*"` at the start results in a regex that matches the end (`/...$/`)
  * `"*"` at the end results in a regex that matches the start (`/^.../`)

@GermanBluefox @Apollon77 These are quite substantial changes. Do we have tests for the $-selector in place to test if I didn't break anything?