### PR TITLE
eventObj: fix enumIds getter

### DIFF
--- a/lib/eventObj.js
+++ b/lib/eventObj.js
@@ -144,7 +144,7 @@ function createEventObject(context, id, state, oldState) {
                     let enumIds = {};
                     let enumNames = {};
                     getObjectEnumsSync(context, this.id, enumIds, enumNames);
-                    Object.defineProperty(context, this, 'enumNames', {value: enumNames});
+                    Object.defineProperty(this, 'enumNames', {value: enumNames});
                     return doGetter(this, 'enumIds', enumIds);
                 },
                 configurable: true


### PR DESCRIPTION
`Object.defineProperty` accepts 3 arguments, at this point it had 4. `context` is not used in the other lines where `Object.defineProperty` is called.