### PR TITLE
Add callback for onStop to typescript definition

### DIFF
--- a/lib/javascript.d.ts
+++ b/lib/javascript.d.ts
@@ -704,7 +704,7 @@ declare global {
 	): boolean;
 
 	/** Sets up a callback which is called when the script stops */
-	function onStop(callback: () => void, timeout?: number): void;
+	function onStop(callback: (cb?: ()=>void) => void, timeout?: number): void;
 
 	function formatValue(value: number | string, format?: any): string;
 	function formatValue(value: number | string, decimals: number, format?: any): string;


### PR DESCRIPTION
This adds the callback for onStop to the typescript definition.
This is needed for longer taking actions where you want to set the timeout for a long time and call the callback once your shutdown action is finished.