### PR TITLE
$-selector: fix boolean attribute comparison and filtering

### DIFF
--- a/lib/sandbox.js
+++ b/lib/sandbox.js
@@ -29,10 +29,10 @@
  * @param {{[prop: string]: any} & SandboxContext} context
  */
 function sandBox(script, name, verbose, debug, context) {
-    const consts   = require(__dirname + '/consts');
-    const words    = require(__dirname + '/words');
-    const eventObj = require(__dirname + '/eventObj');
-    const patternCompareFunctions = require(__dirname + '/patternCompareFunctions');
+    const consts   = require('./consts');
+    const words    = require('./words');
+    const eventObj = require('./eventObj');
+    const patternCompareFunctions = require('./patternCompareFunctions');
     const nodeSchedule = require('node-schedule');
 
     const adapter  = context.adapter;
@@ -161,7 +161,6 @@ function sandBox(script, name, verbose, debug, context) {
             // wildcard potentially in the middle, match whatever
             return new RegExp(str.replace(/\./g, '\\.').replace(/\*/g, '.*'));
         }
-
     }
 
     /**
@@ -182,6 +181,22 @@ function sandBox(script, name, verbose, debug, context) {
         } else {
             return selector;
         }
+    }
+
+    /**
+     * Tests if a value loosely equals (==) the reference string. 
+     * In contrast to the equality operator, this treats true == "true" aswell
+     * so we can test common and native attributes for boolean values
+     * @param {boolean | string | number | undefined} value The value to compare with the reference
+     * @param {string} reference The reference to compare the value to
+     */
+    function looselyEqualsString(value, reference) {
+        // For booleans, compare the string representation
+        // For other types do a loose comparison
+        return (typeof value === 'boolean') 
+            ? (value && reference === 'true') || (!value && reference === 'false')
+            : value == reference
+        ;
     }
 
     const sandbox = {
@@ -385,62 +400,58 @@ function sandBox(script, name, verbose, debug, context) {
              */
             function applyIDSelectors(objId, selectors) {
                 // Only keep the ID if it matches every ID selector
-                selectors.every(selector => {
+                return selectors.every(selector => {
                     return selector.idRegExp == null || selector.idRegExp.test(objId);
                 });
             }
 
             /** 
-             * applies all selectors targeting the Object common properties
-             * @param {string[]} IDs
+             * Applies all selectors targeting the Object common properties
+             * @param {string} objId - The ID of the object in question
              */
-            function applyCommonSelectors(IDs) {
-                // Only keep the IDs that match every common selector
-                return IDs.filter(id => {
-                    if (objects[id] == null || objects[id].common == null) return false;
-                    const objCommon = objects[id].common;
-                    return commonSelectors.every(selector => {
-                        return (
-                            // match existing properties
-                            (selector.value === undefined && objCommon[selector.attr] !== undefined)
-                            // match exact values
-                            || (objCommon[selector.attr] == selector.value)
-                        );
-                    });
+            function applyCommonSelectors(objId) {
+                const obj = objects[objId];
+                if (obj == null || obj.common == null) return false;
+                const objCommon = obj.common;
+                // make sure this object satisfies all selectors
+                return commonSelectors.every(selector => {
+                    return (
+                        // ensure a property exists
+                        (selector.value === undefined && objCommon[selector.attr] !== undefined)
+                        // or match exact values
+                        || looselyEqualsString(objCommon[selector.attr], selector.value)
+                    );
                 });
             }
 
             /** 
-             * applies all selectors targeting the Object native properties
-             * @param {string[]} IDs
+             * Applies all selectors targeting the Object native properties
+             * @param {string} objId - The ID of the object in question
              */
-            function applyNativeSelectors(IDs) {
-                // Only keep the IDs that match every native selector
-                return IDs.filter(id => {
-                    if (objects[id] == null || objects[id].native == null) return false;
-                    const objNative = objects[id].native;
-                    return nativeSelectors.every(selector => {
-                        return (
-                            // match existing properties
-                            (selector.value === undefined && objNative[selector.attr] !== undefined)
-                            // match exact values
-                            || (objNative[selector.attr] == selector.value)
-                        );
-                    });
+            function applyNativeSelectors(objId) {
+                const obj = objects[objId];
+                if (obj == null || obj.native == null) return false;
+                const objNative = obj.native;
+                // make sure this object satisfies all selectors
+                return nativeSelectors.every(selector => {
+                    return (
+                        // ensure a property exists
+                        (selector.value === undefined && objNative[selector.attr] !== undefined)
+                        // or match exact values
+                        || looselyEqualsString(objNative[selector.attr], selector.value)
+                    );
                 });
             }
 
             /** 
-             * applies all selectors targeting the Objects enums
-             * @param {string[]} IDs
+             * Applies all selectors targeting the Objects enums
+             * @param {string} objId - The ID of the object in question
              */
-            function applyEnumSelectors(IDs) {
-                // Only keep the IDs which are in all enums requested by the selectors
-                return IDs.filter(id => {
-                    const enumIds = [];
-                    eventObj.getObjectEnumsSync(context, id, enumIds);
-                    return enumSelectors.every(_enum => enumIds.indexOf(_enum) > -1);
-                });
+            function applyEnumSelectors(objId) {
+                const enumIds = [];
+                eventObj.getObjectEnumsSync(context, objId, enumIds);
+                // make sure this object satisfies all selectors
+                return enumSelectors.every(_enum => enumIds.indexOf(_enum) > -1);
             }
 
             /** @type {string[]} */
@@ -451,18 +462,18 @@ function sandBox(script, name, verbose, debug, context) {
                 res = Object.keys(context.channels)
                     // filter out those that don't match every ID selector for the channel ID
                     .filter(channelId => applyIDSelectors(channelId, objectIdSelectors))
+                    // filter out those that don't match every common selector
+                    .filter(channelId => applyCommonSelectors(channelId))
+                    // filter out those that don't match every native selector
+                    .filter(channelId => applyNativeSelectors(channelId))
+                    // filter out those that don't match every enum selector
+                    .filter(channelId => applyEnumSelectors(channelId))
                     // retrieve the state ID collection for all remaining channels
                     .map(id => context.channels[id])
-                    // filter out those that don't match every common selector
-                    .filter(stateIDs => applyCommonSelectors(stateIDs))
-                    // filter out those that don't match every native selector
-                    .filter(stateIDs => applyNativeSelectors(stateIDs))
-                    // filter out those that don't match every enum selector
-                    .filter(stateIDs => applyEnumSelectors(stateIDs))
-                    // flatten the remaining array to get only the state IDs
+                    // and flatten the array to get only the state IDs
                     .reduce((acc, next) => acc.concat(next), [])
                     // now filter out those that don't match every ID selector for the state ID
-                    .filter(stateIDs => applyIDSelectors(stateIDs, stateIdSelectors))
+                    .filter(stateId => applyIDSelectors(stateId, stateIdSelectors))
                 ;
 
             } else if (name === 'device') {
@@ -470,18 +481,18 @@ function sandBox(script, name, verbose, debug, context) {
                 res = Object.keys(context.devices)
                     // filter out those that don't match every ID selector for the channel ID
                     .filter(deviceId => applyIDSelectors(deviceId, objectIdSelectors))
+                    // filter out those that don't match every common selector
+                    .filter(deviceId => applyCommonSelectors(deviceId))
+                    // filter out those that don't match every native selector
+                    .filter(deviceId => applyNativeSelectors(deviceId))
+                    // filter out those that don't match every enum selector
+                    .filter(deviceId => applyEnumSelectors(deviceId))
                     // retrieve the state ID collection for all remaining devices
                     .map(id => context.devices[id])
-                    // filter out those that don't match every common selector
-                    .filter(stateIDs => applyCommonSelectors(stateIDs))
-                    // filter out those that don't match every native selector
-                    .filter(stateIDs => applyNativeSelectors(stateIDs))
-                    // filter out those that don't match every enum selector
-                    .filter(stateIDs => applyEnumSelectors(stateIDs))
-                    // flatten the remaining array to get only the state IDs
+                    // and flatten the array to get only the state IDs
                     .reduce((acc, next) => acc.concat(next), [])
                     // now filter out those that don't match every ID selector for the state ID
-                    .filter(stateIDs => applyIDSelectors(stateIDs, stateIdSelectors))
+                    .filter(stateId => applyIDSelectors(stateId, stateIdSelectors))
                 ;
 
             } else {
@@ -493,17 +504,17 @@ function sandBox(script, name, verbose, debug, context) {
                     res = res.filter(id => r.test(id));
                 }
 
-                // filter out those that don't match every ID selector for the object ID or the state ID
                 res = res
+                    // filter out those that don't match every ID selector for the object ID or the state ID
                     .filter(id => applyIDSelectors(id, objectIdSelectors))
                     .filter(id => applyIDSelectors(id, stateIdSelectors))
+                    // filter out those that don't match every common selector
+                    .filter(id => applyCommonSelectors(id))
+                    // filter out those that don't match every native selector
+                    .filter(id => applyNativeSelectors(id))
+                    // filter out those that don't match every enum selector
+                    .filter(id => applyEnumSelectors(id))
                 ;
-                // filter out those that don't match every common selector
-                res = applyCommonSelectors(res);
-                // filter out those that don't match every native selector
-                res = applyNativeSelectors(res);
-                // filter out those that don't match every enum selector
-                res = applyEnumSelectors(res);
             }
 
             for (let i = 0; i < res.length; i++) {

--- a/main.js
+++ b/main.js
@@ -42,10 +42,10 @@ const mods = {
     wake_on_lan:      require('wake_on_lan')
 };
 
-const utils    = require(__dirname + '/lib/utils'); // Get common adapter utils
-const words    = require(__dirname + '/lib/words');
-const sandBox  = require(__dirname + '/lib/sandbox');
-const eventObj = require(__dirname + '/lib/eventObj');
+const utils    = require('./lib/utils'); // Get common adapter utils
+const words    = require('./lib/words');
+const sandBox  = require('./lib/sandbox');
+const eventObj = require('./lib/eventObj');
 
 // for node version <= 0.12
 if (''.startsWith === undefined) {


### PR DESCRIPTION
Previously the $ selector would compare common/native object values with selector strings directly. This would result in selectors like `"(write=true)"` not working.

In addition, PR #137 had a bug where the filters were applied to the wrong objects. This is fixed aswell now.