### PR TITLE
$-selector: Ensure the selector is a string and improve error messages

### DIFF
--- a/lib/sandbox.js
+++ b/lib/sandbox.js
@@ -230,6 +230,9 @@ function sandBox(script, name, verbose, debug, context) {
             __subscriptions: 0,
             __schedules: 0
         },
+        /**
+         * @param {string} selector
+         */
         $:         function (selector) {
             // following is supported
             // 'type[commonAttr=something]', 'id[commonAttr=something]', id(enumName="something")', id{nativeName="something"}
@@ -261,59 +264,62 @@ function sandBox(script, name, verbose, debug, context) {
             let currentCommonString    = '';
             let currentNativeString    = '';
             let currentEnumString     = '';
-            // let parts;
-            // let len;
 
             // parse string
-            for (let i = 0; i < selector.length; i++) {
-                if (selector[i] === '{') {
-                    isInsideName = false;
-                    if (isInsideCommonString || isInsideEnumString || isInsideNativeString) {
-                        // Error
-                        return [];
-                    }
-                    isInsideNativeString = true;
-                } else if (selector[i] === '}') {
-                    isInsideNativeString = false;
-                    nativeStrings.push(currentNativeString);
-                    currentNativeString = '';
-                } else if (selector[i] === '[') {
-                    isInsideName = false;
-                    if (isInsideCommonString || isInsideEnumString || isInsideNativeString) {
-                        // Error
-                        return [];
-                    }
-                    isInsideCommonString = true;
-                } else if (selector[i] === ']') {
-                    isInsideCommonString = false;
-                    commonStrings.push(currentCommonString);
-                    currentCommonString = '';
-                } else if (selector[i] === '(') {
-                    isInsideName = false;
-                    if (isInsideCommonString || isInsideEnumString || isInsideNativeString) {
-                        // Error
-                        return [];
-                    }
-                    isInsideEnumString = true;
-                } else if (selector[i] === ')') {
-                    isInsideEnumString = false;
-                    enumStrings.push(currentEnumString);
-                    currentEnumString = '';
-                } else if (isInsideName) {
-                    name += selector[i];
-                } else if (isInsideCommonString) {
-                    currentCommonString += selector[i];
-                } else if (isInsideEnumString) {
-                    currentEnumString += selector[i];
-                } else if (isInsideNativeString) {
-                    currentNativeString += selector[i];
-                } //else {
-                // some error
-                //}
+            let selectorHasInvalidType = false;
+            if (typeof selector === 'string') {
+                for (let i = 0; i < selector.length; i++) {
+                    if (selector[i] === '{') {
+                        isInsideName = false;
+                        if (isInsideCommonString || isInsideEnumString || isInsideNativeString) {
+                            // Error
+                            break;
+                        }
+                        isInsideNativeString = true;
+                    } else if (selector[i] === '}') {
+                        isInsideNativeString = false;
+                        nativeStrings.push(currentNativeString);
+                        currentNativeString = '';
+                    } else if (selector[i] === '[') {
+                        isInsideName = false;
+                        if (isInsideCommonString || isInsideEnumString || isInsideNativeString) {
+                            // Error
+                            break;
+                        }
+                        isInsideCommonString = true;
+                    } else if (selector[i] === ']') {
+                        isInsideCommonString = false;
+                        commonStrings.push(currentCommonString);
+                        currentCommonString = '';
+                    } else if (selector[i] === '(') {
+                        isInsideName = false;
+                        if (isInsideCommonString || isInsideEnumString || isInsideNativeString) {
+                            // Error
+                            break;
+                        }
+                        isInsideEnumString = true;
+                    } else if (selector[i] === ')') {
+                        isInsideEnumString = false;
+                        enumStrings.push(currentEnumString);
+                        currentEnumString = '';
+                    } else if (isInsideName) {
+                        name += selector[i];
+                    } else if (isInsideCommonString) {
+                        currentCommonString += selector[i];
+                    } else if (isInsideEnumString) {
+                        currentEnumString += selector[i];
+                    } else if (isInsideNativeString) {
+                        currentNativeString += selector[i];
+                    } //else {
+                    // some error
+                    //}
+                }
+            } else {
+                selectorHasInvalidType = true;
             }
 
             // If some error in the selector
-            if (isInsideEnumString || isInsideCommonString || isInsideNativeString) {
+            if (selectorHasInvalidType || isInsideEnumString || isInsideCommonString || isInsideNativeString) {
                 result.length = 0;
                 result.each = function () {
                     return this;
@@ -329,16 +335,21 @@ function sandBox(script, name, verbose, debug, context) {
             }
 
             if (isInsideEnumString) {
-                adapter.log.warn('Invalid selector: enum close bracket cannot be found in "' + selector + '"');
-                result.error = 'Invalid selector: enum close bracket cannot be found';
+                adapter.log.warn('Invalid selector: enum close bracket ")" cannot be found in "' + selector + '"');
+                result.error = 'Invalid selector: enum close bracket ")" cannot be found';
                 return result;
             } else if (isInsideCommonString) {
-                adapter.log.warn('Invalid selector: common close bracket cannot be found in "' + selector + '"');
-                result.error = 'Invalid selector: common close bracket cannot be found';
+                adapter.log.warn('Invalid selector: common close bracket "]" cannot be found in "' + selector + '"');
+                result.error = 'Invalid selector: common close bracket "]" cannot be found';
                 return result;
             } else if (isInsideNativeString) {
-                adapter.log.warn('Invalid selector: native close bracket cannot be found in "' + selector + '"');
-                result.error = 'Invalid selector: native close bracket cannot be found';
+                adapter.log.warn('Invalid selector: native close bracket "}" cannot be found in "' + selector + '"');
+                result.error = 'Invalid selector: native close bracket "}" cannot be found';
+                return result;
+            } else if (selectorHasInvalidType) {
+                const message = `Invalid selector: selector must be a string but is of type ${typeof selector}`;
+                adapter.log.warn(message);
+                result.error = message;
                 return result;
             }
 

--- a/lib/sandbox.js
+++ b/lib/sandbox.js
@@ -232,6 +232,7 @@ function sandBox(script, name, verbose, debug, context) {
         },
         /**
          * @param {string} selector
+         * @returns {iobJS.QueryResult}
          */
         $:         function (selector) {
             // following is supported
@@ -331,6 +332,7 @@ function sandBox(script, name, verbose, debug, context) {
                     return this;
                 };
                 result.on = function () {
+                    return this;
                 };
             }
 


### PR DESCRIPTION
* Ensure that the selector is a string
* Improve/enable error messages for invalid selectors
* For empty results, the `on` function must return `this`.

Fixes: #142