### PR TITLE
Subscribe: Allow matching regular expressions and arrays in more places

### DIFF
--- a/doc/en/javascript.md
+++ b/doc/en/javascript.md
@@ -235,12 +235,13 @@ You can use following parameters to specify the trigger:
 |-----------  |-------     |-------------------                                                                                     |
 | logic       | string     |       "and" or "or" logic to combine the conditions \(default: "and"\)                                 |
 |             |            |                                                                                                        |
-| id          | string     |       name ist equal to given one                                                                      |
-|             | RegExp     |       name matched to regular expression
-|             | Array      |       name matched to a list of given one                                                         |
+| id          | string     |       id is equal to given one                                                                         |
+|             | RegExp     |       id matched to regular expression                                                                 |
+|             | Array      |       id matched to a list of allowed IDs                                                              |
 |             |            |                                                                                                        |
-| name        | string     |       name ist equal to given one                                                                      |
+| name        | string     |       name is equal to given one                                                                       |
 |             | RegExp     |       name matched to regular expression                                                               |
+|             | Array      |       name matched to a list of allowed names                                                          |
 |             |            |                                                                                                        |
 | change      | string     |       "eq", "ne", "gt", "ge", "lt", "le", "any"                                                        |
 |             |   "eq"     |       (equal)            New value must be equal to old one (state.val == oldState.val)                |
@@ -295,15 +296,19 @@ You can use following parameters to specify the trigger:
 |             |            |                                                                                                        |
 | channelId   | string     |       Channel ID must be equal to given one                                                            |
 |             | RegExp     |       Channel ID matched to regular expression                                                         |
+|             | Array      |       Channel ID matched to a list of allowed channel IDs                                              |
 |             |            |                                                                                                        |
 | channelName | string     |       Channel name must be equal to given one                                                          |
 |             | RegExp     |       Channel name matched to regular expression                                                       |
+|             | Array      |       Channel name matched to a list of allowed channel names                                          |
 |             |            |                                                                                                        |
 | deviceId    | string     |       Device ID must be equal to given one                                                             |
 |             | RegExp     |       Device ID matched to regular expression                                                          |
+|             | Array      |       Device ID matched to a list of allowed device IDs                                                |
 |             |            |                                                                                                        |
 | deviceName  | string     |       Device name must be equal to given one                                                           |
 |             | RegExp     |       Device name matched to regular expression                                                        |
+|             | Array      |       Device name matched to a list of allowed device names                                            |
 |             |            |                                                                                                        |
 | enumId      | string     |       State belongs to given enum                                                                      |
 |             | RegExp     |       One enum ID of state satisfy the given regular expression                                        |
@@ -312,9 +317,20 @@ You can use following parameters to specify the trigger:
 |             | RegExp     |       One enum name of state satisfy the given regular expression                                      |
 |             |            |                                                                                                        |
 | from        | string     |       New value is from defined adapter                                                                |
+|             | RegExp     |       New value is from an adapter that matches the regular expression                                 |
+|             | Array      |       New value is from an adapter that appears in the given list of allowed adapters                  |
+|             |            |                                                                                                        |
 | fromNe      | string     |       New value is not from defined adapter                                                            |
+|             | RegExp     |       New value is not from an adapter that matches the regular expression                             |
+|             | Array      |       New value is not from an adapter that appears in the given list of forbidden adapters            |
+|             |            |                                                                                                        |
 | oldFrom     | string     |       Old value is from defined adapter                                                                |
+|             | RegExp     |       Old value is from an adapter that matches the regular expression                                 |
+|             | Array      |       Old value is from an adapter that appears in the given list of allowed adapters                  |
+|             |            |                                                                                                        |
 | oldFromNe   | string     |       Old value is not from defined adapter                                                            |
+|             | RegExp     |       Old value is not from an adapter that matches the regular expression                             |
+|             | Array      |       Old value is not from an adapter that appears in the given list of forbidden adapters            |
 
 Examples:
 Trigger on all states with ID `'*.STATE'` if they are acknowledged and have new value `true`.

--- a/doc/en/javascript.md
+++ b/doc/en/javascript.md
@@ -311,10 +311,12 @@ You can use following parameters to specify the trigger:
 |             | Array      |       Device name matched to a list of allowed device names                                            |
 |             |            |                                                                                                        |
 | enumId      | string     |       State belongs to given enum                                                                      |
-|             | RegExp     |       One enum ID of state satisfy the given regular expression                                        |
+|             | RegExp     |       One enum ID of the state satisfies the given regular expression                                  |
+|             | Array      |       One enum ID of the state is in the given list of enum IDs                                        |
 |             |            |                                                                                                        |
 | enumName    | string     |       State belongs to given enum                                                                      |
-|             | RegExp     |       One enum name of state satisfy the given regular expression                                      |
+|             | RegExp     |       One enum name of the state satisfies the given regular expression                                |
+|             | Array      |       One enum name of the state is in the given list of enum names                                    |
 |             |            |                                                                                                        |
 | from        | string     |       New value is from defined adapter                                                                |
 |             | RegExp     |       New value is from an adapter that matches the regular expression                                 |

--- a/lib/javascript.d.ts
+++ b/lib/javascript.d.ts
@@ -231,7 +231,7 @@ declare global {
 			/** name is equal or matches to given one or name marches to any item in given list */
 			id?: string | string[] | SubscribeOptions[] | RegExp | RegExp[];
 			/** name is equal or matches to given one */
-			name?: string | RegExp;
+			name?: string | string[] | RegExp;
 			/** type of change */
 			change?: "eq" | "ne" | "gt" | "ge" | "lt" | "le" | "any";
 			val?: any;
@@ -302,25 +302,25 @@ declare global {
 			/** Previous last change time stamp must be smaller than given one (oldState.lc < lc) */
 			oldLcLe?: string;
 			/** Channel ID must be equal or match to given one */
-			channelId?: string | RegExp;
+			channelId?: string | string[] | RegExp;
 			/** Channel name must be equal or match to given one */
-			channelName?: string | RegExp;
+			channelName?: string | string[] | RegExp;
 			/** Device ID must be equal or match to given one */
-			deviceId?: string | RegExp;
+			deviceId?: string | string[] | RegExp;
 			/** Device name must be equal or match to given one */
-			deviceName?: string | RegExp;
+			deviceName?: string | string[] | RegExp;
 			/** State belongs to given enum or one enum ID of state satisfy the given regular expression */
 			enumId?: string | RegExp;
 			/** State belongs to given enum or one enum name of state satisfy the given regular expression */
 			enumName?: string | RegExp;
 			/** New value is from defined adapter */
-			from?: string;
+			from?: string | string[] | RegExp;
 			/** New value is not from defined adapter */
-			fromNe?: string;
+			fromNe?: string | string[] | RegExp;
 			/** Old value is from defined adapter */
-			oldFrom?: string;
+			oldFrom?: string | string[] | RegExp;
 			/** Old value is not from defined adapter */
-			oldFromNe?: string;
+			oldFromNe?: string | string[] | RegExp;
 		}
 
 		interface QueryResult {

--- a/lib/javascript.d.ts
+++ b/lib/javascript.d.ts
@@ -310,9 +310,9 @@ declare global {
 			/** Device name must be equal or match to given one */
 			deviceName?: string | string[] | RegExp;
 			/** State belongs to given enum or one enum ID of state satisfy the given regular expression */
-			enumId?: string | RegExp;
+			enumId?: string | string[] | RegExp;
 			/** State belongs to given enum or one enum name of state satisfy the given regular expression */
-			enumName?: string | RegExp;
+			enumName?: string | string[] | RegExp;
 			/** New value is from defined adapter */
 			from?: string | string[] | RegExp;
 			/** New value is not from defined adapter */
@@ -704,7 +704,7 @@ declare global {
 	): boolean;
 
 	/** Sets up a callback which is called when the script stops */
-	function onStop(callback: (cb?: ()=>void) => void, timeout?: number): void;
+	function onStop(callback: (cb?: () => void) => void, timeout?: number): void;
 
 	function formatValue(value: number | string, format?: any): string;
 	function formatValue(value: number | string, decimals: number, format?: any): string;

--- a/lib/patternCompareFunctions.js
+++ b/lib/patternCompareFunctions.js
@@ -4,15 +4,31 @@ function isRegExp(obj) {
     return !!(obj && obj.test && obj.exec && (obj.ignoreCase || obj.ignoreCase === false));
 }
 
-function stringOrRegExpCompare(name, pattern) {
-    const field = pattern[name];
+/**
+ * 
+ * @param {{}} pattern The pattern object to use
+ * @param {string} propName The name of the property to compare
+ * @param {(event: any) => any} [eventPropertyExtractor] If given, this function is used to extract the property value from the event object. Otherwise the propName is used
+ */
+function stringOrRegExpCompare(pattern, propName, eventPropertyExtractor) {
+    /** @type {RegExp | string | string[]} */
+    const field = pattern[propName];
+    const hasExtractor = typeof eventPropertyExtractor === 'function';
     if (isRegExp(field)) {
         return function (event) {
-            return (event[name] && field.test(event[name]));
+            const eventValue = hasExtractor ? eventPropertyExtractor(event) : event[propName];
+            return (eventValue != null && /** @type {RegExp} */ (field).test(eventValue));
         };
+    } else if (Array.isArray(field)) {
+        return function (event) {
+            const eventValue = hasExtractor ? eventPropertyExtractor(event) : event[propName];
+            // An array matches when any element is found that satisfies the constraint
+            return eventValue != null  && field.find(f => f === eventValue) != null;
+        }
     } else {
         return function (event) {
-            return (event[name] && field === event[name]);
+            const eventValue = hasExtractor ? eventPropertyExtractor(event) : event[propName];
+            return (eventValue != null && field === eventValue);
         };
     }
 }
@@ -21,22 +37,10 @@ const patternCompareFunctions = {
 
     logic: function (pattern) {
     },
-    //id: stringOrRegExpCompare.bind(1, 'id'),
-    id: function (pattern) {
-        const pid = pattern.id;
-        if (isRegExp(pid)) {
-            return function (event) {
-                //return event.id && event.id.match (pattern.id);
-                return event.id && pid.test(event.id);
-            };
-        } else {
-            return function (event) {
-                return (event.id && pid === event.id);
-            };
-        }
-    },
 
-    name: stringOrRegExpCompare.bind(1, 'name'),
+    id: (pattern) => stringOrRegExpCompare(pattern, "id"),
+
+    name: (pattern) => stringOrRegExpCompare(pattern, "name"),
 
     change: function (pattern) {
         switch (pattern.change) {
@@ -270,36 +274,26 @@ const patternCompareFunctions = {
         };
     },
 
-    from: function (pattern) {
-        const pfrom = pattern.from;
-        return function (event) {
-            return pfrom === event.newState.from;
-        };
-    },
-    fromNe: function (pattern) {
-        const pfromNe = pattern.fromNe;
-        return function (event) {
-            return pfromNe !== event.newState.from;
-        };
-    },
+    from: (pattern) => stringOrRegExpCompare(pattern, "from",
+        (event) => event && event.newState && event.newState.from
+    ),
 
-    oldFrom: function (pattern) {
-        const poldFrom = pattern.oldFrom;
-        return function (event) {
-            return poldFrom === event.oldState.from;
-        };
-    },
-    oldFromNe: function (pattern) {
-        const poldFromNe = pattern.oldFromNe;
-        return function (event) {
-            return poldFromNe !== event.oldState.from;
-        };
-    },
+    fromNe: (pattern) => !stringOrRegExpCompare(pattern, "fromNe",
+        (event) => event && event.newState && event.newState.from
+    ),
 
-    channelId:   stringOrRegExpCompare.bind(1, 'channelId'),
-    channelName: stringOrRegExpCompare.bind(1, 'channelName'),
-    deviceId:    stringOrRegExpCompare.bind(1, 'deviceId'),
-    deviceName:  stringOrRegExpCompare.bind(1, 'deviceName'),
+    oldFrom: (pattern) => stringOrRegExpCompare(pattern, "oldFrom",
+        (event) => event && event.oldState && event.oldState.from
+    ),
+
+    oldFromNe: (pattern) => !stringOrRegExpCompare(pattern, "oldFromNe",
+        (event) => event && event.oldState && event.oldState.from
+    ),
+
+    channelId: (pattern) => stringOrRegExpCompare(pattern, "channelId"),
+    channelName: (pattern) => stringOrRegExpCompare(pattern, "channelName"),
+    deviceId: (pattern) => stringOrRegExpCompare(pattern, "deviceId"),
+    deviceName: (pattern) => stringOrRegExpCompare(pattern, "deviceName"),
 
     enumId: function (pattern) {
         const penumId = pattern.enumId;

--- a/lib/patternCompareFunctions.js
+++ b/lib/patternCompareFunctions.js
@@ -24,7 +24,7 @@ function stringOrRegExpCompare(pattern, propName, eventPropertyExtractor) {
             const eventValue = hasExtractor ? eventPropertyExtractor(event) : event[propName];
             // An array matches when any element is found that satisfies the constraint
             return eventValue != null  && field.find(f => f === eventValue) != null;
-        }
+        };
     } else {
         return function (event) {
             const eventValue = hasExtractor ? eventPropertyExtractor(event) : event[propName];
@@ -38,9 +38,9 @@ const patternCompareFunctions = {
     logic: function (pattern) {
     },
 
-    id: (pattern) => stringOrRegExpCompare(pattern, "id"),
+    id: (pattern) => stringOrRegExpCompare(pattern, 'id'),
 
-    name: (pattern) => stringOrRegExpCompare(pattern, "name"),
+    name: (pattern) => stringOrRegExpCompare(pattern, 'name'),
 
     change: function (pattern) {
         switch (pattern.change) {
@@ -274,67 +274,93 @@ const patternCompareFunctions = {
         };
     },
 
-    from: (pattern) => stringOrRegExpCompare(pattern, "from",
+    from: (pattern) => stringOrRegExpCompare(pattern, 'from',
         (event) => event && event.newState && event.newState.from
     ),
 
-    fromNe: (pattern) => !stringOrRegExpCompare(pattern, "fromNe",
+    fromNe: (pattern) => !stringOrRegExpCompare(pattern, 'fromNe',
         (event) => event && event.newState && event.newState.from
     ),
 
-    oldFrom: (pattern) => stringOrRegExpCompare(pattern, "oldFrom",
+    oldFrom: (pattern) => stringOrRegExpCompare(pattern, 'oldFrom',
         (event) => event && event.oldState && event.oldState.from
     ),
 
-    oldFromNe: (pattern) => !stringOrRegExpCompare(pattern, "oldFromNe",
+    oldFromNe: (pattern) => !stringOrRegExpCompare(pattern, 'oldFromNe',
         (event) => event && event.oldState && event.oldState.from
     ),
 
-    channelId: (pattern) => stringOrRegExpCompare(pattern, "channelId"),
-    channelName: (pattern) => stringOrRegExpCompare(pattern, "channelName"),
-    deviceId: (pattern) => stringOrRegExpCompare(pattern, "deviceId"),
-    deviceName: (pattern) => stringOrRegExpCompare(pattern, "deviceName"),
+    channelId: (pattern) => stringOrRegExpCompare(pattern, 'channelId'),
+    channelName: (pattern) => stringOrRegExpCompare(pattern, 'channelName'),
+    deviceId: (pattern) => stringOrRegExpCompare(pattern, 'deviceId'),
+    deviceName: (pattern) => stringOrRegExpCompare(pattern, 'deviceName'),
 
-    enumId: function (pattern) {
+    enumId: (pattern) => {
+        /** @type {RegExp | string | string[]} */
         const penumId = pattern.enumId;
+
+        function ensureEnumIDsIsArray(enumIds) {
+            if (!Array.isArray(enumIds)) {
+                console.error(`enumIds is of type ${typeof enumIds} but should be an array: ${JSON.stringify(enumIds)}`);
+                return false;
+            }
+            return true;
+        }
+
         if (isRegExp(penumId)) {
             return function (event) {
-                for (let i = 0; i < event.enumIds.length; i++) {
-                    //if (event.enumIds[i].match (penumId)) {
-                    if (penumId.test(event.enumIds[i])) {
-                        return true;
-                    }
-                }
-                return false;
+                const enumIds = event.enumIds;
+                if (enumIds == null || !ensureEnumIDsIsArray(enumIds)) return false;
+                // Test if any enum name matches the regex:
+                return enumIds.find(e => /** @type {RegExp} */ (penumId).test(e)) != null;
+            };
+        } else if (Array.isArray(penumId)) {
+            return function (event) {
+                const enumIds = event.enumIds;
+                if (enumIds == null || !ensureEnumIDsIsArray(enumIds)) return false;
+                // Test if the enum names of the event and the given array intersect
+                return enumIds.find(e => penumId.indexOf(e) > -1) != null;
             };
         } else {
             return function (event) {
-                return (event.enumIds && event.enumIds.indexOf(penumId) !== -1);
+                const enumIds = event.enumIds;
+                if (enumIds == null || !ensureEnumIDsIsArray(enumIds)) return false;
+                return (enumIds && enumIds.indexOf(penumId) !== -1);
             };
         }
     },
 
     enumName: function (pattern) {
+        /** @type {RegExp | string | string[]} */
         const penumName = pattern.enumName;
+
+        function ensureEnumNamesIsArray(enumNames) {
+            if (!Array.isArray(enumNames)) {
+                console.error(`enumNames is of type ${typeof enumNames} but should be an array: ${JSON.stringify(enumNames)}`);
+                return false;
+            }
+            return true;
+        }
+
         if (isRegExp(penumName)) {
             return function (event) {
-                if (event.enumNames) {
-                    if (!(event.enumNames instanceof Array)) {
-                        console.error('Invalid type of enumNames: ' + (typeof event.enumNames) + ' ' + JSON.stringify(event.enumNames));
-                        return false;
-                    }
-
-                    for (let j = 0; j < event.enumNames.length; j++) {
-                        if (penumName.test(event.enumNames[j])) {
-                            return true;
-                        }
-                    }
-                }
-                return false;
+                const enumNames = event.enumNames;
+                if (enumNames == null || !ensureEnumNamesIsArray(enumNames)) return false;
+                // Test if any enum name matches the regex:
+                return enumNames.find(e => /** @type {RegExp} */ (penumName).test(e)) != null;
+            };
+        } else if (Array.isArray(penumName)) {
+            return function (event) {
+                const enumNames = event.enumNames;
+                if (enumNames == null || !ensureEnumNamesIsArray(enumNames)) return false;
+                // Test if the enum names of the event and the given array intersect
+                return enumNames.find(e => penumName.indexOf(e) > -1) != null;
             };
         } else {
             return function (event) {
-                return (event.enumNames && event.enumNames.indexOf(penumName) !== -1);
+                const enumNames = event.enumNames;
+                if (enumNames == null || !ensureEnumNamesIsArray(enumNames)) return false;
+                return (enumNames && enumNames.indexOf(penumName) !== -1);
             };
         }
     }


### PR DESCRIPTION
This adds the possibility to filter subscriptions with arrays and regular expressions for more properties. EnumIDs and EnumNames are still missing for that, but I have to take a 2nd look at those methods first...

Fixes: #144 