### PR TITLE
Fix tests for Object and Array

### DIFF
--- a/lib/sandbox.js
+++ b/lib/sandbox.js
@@ -1,4 +1,9 @@
+/// <reference path="./javascript.d.ts" />
 'use strict';
+
+const isObject = require('./tools').isObject;
+const isArray  = require('./tools').isArray;
+
 // let context = {
 //     adapter,
 //     mods,
@@ -197,6 +202,17 @@ function sandBox(script, name, verbose, debug, context) {
             ? (value && reference === 'true') || (!value && reference === 'false')
             : value == reference
         ;
+    }
+
+    /**
+     * Tests if the given value has the correct type as defined in common.type
+     * @param {iobJS.CommonType} commonType
+     * @param {any} value
+     */
+    function checkCommonType(commonType, value) {
+        return commonType === 'array' ? isArray(value)
+            : commonType === 'object' ? isObject(value)
+            : commonType === typeof value;
     }
 
     const sandbox = {
@@ -564,7 +580,7 @@ function sandBox(script, name, verbose, debug, context) {
                 }
 
                 if (isAck === true || isAck === false || isAck === 'true' || isAck === 'false') {
-                    if (typeof state === 'object') {
+                    if (isObject(state)) {
                         state.ack = isAck;
                     } else {
                         state = {val: state, ack: isAck};
@@ -646,7 +662,7 @@ function sandBox(script, name, verbose, debug, context) {
             }
 
             // try to detect astro or cron (by spaces)
-            if (typeof pattern === 'object' || (typeof pattern === 'string' && pattern.match(/[,/\d*]+\s[,/\d*]+\s[,/\d*]+/))) {
+            if (isObject(pattern) || (typeof pattern === 'string' && pattern.match(/[,/\d*]+\s[,/\d*]+\s[,/\d*]+/))) {
                 if (pattern.astro) {
                     return sandbox.schedule(pattern, callbackOrId);
                 } else if (pattern.time) {
@@ -659,7 +675,7 @@ function sandBox(script, name, verbose, debug, context) {
             sandbox.__engine.__subscriptions += 1;
 
             // source is set by regexp if defined as /regexp/
-            if (typeof pattern !== 'object' || pattern instanceof RegExp || pattern.source) {
+            if (!isObject(pattern) || pattern instanceof RegExp || pattern.source) {
                 pattern = {id: pattern, change: 'ne'};
             }
 
@@ -769,7 +785,7 @@ function sandBox(script, name, verbose, debug, context) {
                 return result;
             }
             if (sandbox.verbose) sandbox.log('adapterUnsubscribe(id=' + idOrObject + ')', 'info');
-            if (typeof idOrObject === 'object') {
+            if (isObject(idOrObject)) {
                 for (let i = context.subscriptions.length - 1; i >= 0; i--) {
                     if (context.subscriptions[i] === idOrObject) {
                         unsubscribePattern(context.subscriptions[i].pattern.id);
@@ -962,7 +978,7 @@ function sandBox(script, name, verbose, debug, context) {
             }
 
             if (isAck === true || isAck === false || isAck === 'true' || isAck === 'false') {
-                if (typeof state === 'object') {
+                if (isObject(state)) {
                     state.ack = isAck;
                 } else {
                     state = {val: state, ack: isAck};
@@ -980,20 +996,20 @@ function sandBox(script, name, verbose, debug, context) {
                 common.type !== 'mixed' &&
                 common.type !== 'file'  &&
                 common.type !== 'json') {
-                if (state && typeof state === 'object' && state.val !== undefined) {
-                    if (common.type !== typeof state.val) {
+                if (state && isObject(state) && state.val !== undefined) {
+                    if (!checkCommonType(common.type, state.val)) {
                         context.logWithLineInfo && context.logWithLineInfo.warn('Wrong type of ' + id + ': "' + typeof state.val + '". Please fix, while deprecated and will not work in next versions.');
                         //return;
                     }
                 } else {
-                    if (common.type !== typeof state) {
+                    if (!checkCommonType(common.type, state)) {
                         context.logWithLineInfo && context.logWithLineInfo.warn('Wrong type of ' + id + ': "' + typeof state + '". Please fix, while deprecated and will not work in next versions.');
                         //return;
                     }
                 }
             }
             // Check min and max of value
-            if (typeof state === 'object' && state) {
+            if (isObject(state)) {
                 if (common && typeof state.val === 'number') {
                     if (common.min !== undefined && state.val < common.min) state.val = common.min;
                     if (common.max !== undefined && state.val > common.max) state.val = common.max;
@@ -1225,8 +1241,8 @@ function sandBox(script, name, verbose, debug, context) {
                     id:     context.timerId,
                     ts:     Date.now(),
                     delay:  delay,
-                    val:    typeof state === 'object' && state.val !== undefined ? state.val : state,
-                    ack:    typeof state === 'object' && state.val !== undefined && state.ack !== undefined ? state.ack : isAck
+                    val:    isObject(state) && state.val !== undefined ? state.val : state,
+                    ack:    isObject(state) && state.val !== undefined && state.ack !== undefined ? state.ack : isAck
                 });
                 return context.timerId;
             }
@@ -1470,13 +1486,13 @@ function sandBox(script, name, verbose, debug, context) {
                 callback      = forceCreation;
                 forceCreation = undefined;
             }
-            if (typeof initValue === 'object') {
+            if (isObject(initValue)) {
                 common        = initValue;
                 native        = forceCreation;
                 forceCreation = undefined;
                 initValue     = undefined;
             }
-            if (typeof forceCreation === 'object') {
+            if (isObject(forceCreation)) {
                 common        = forceCreation;
                 native        = common;
                 forceCreation = undefined;
@@ -1575,7 +1591,7 @@ function sandBox(script, name, verbose, debug, context) {
                     if (err) adapter.log.warn('Cannot set object "' + name + '": ' + err);
 
                     if (initValue !== undefined) {
-                        if (typeof initValue === 'object' && initValue.ack !== undefined) {
+                        if (isObject(initValue) && initValue.ack !== undefined) {
                             adapter.setState(name, initValue, callback);
                         } else {
                             adapter.setState(name, initValue, true, callback);
@@ -1605,7 +1621,7 @@ function sandBox(script, name, verbose, debug, context) {
 
                                 if (initValue !== undefined) {
                                     adapter.setForeignState(name, initValue, callback);
-                                    if (typeof initValue === 'object' && initValue.ack !== undefined) {
+                                    if (isObject(initValue) && initValue.ack !== undefined) {
                                         adapter.setForeignState(name, initValue, callback);
                                     } else {
                                         adapter.setForeignState(name, initValue, true, callback);
@@ -1623,7 +1639,7 @@ function sandBox(script, name, verbose, debug, context) {
                                 if (err) adapter.log.warn('Cannot set object "' + name + '": ' + err);
 
                                 if (initValue !== undefined) {
-                                    if (typeof initValue === 'object' && initValue.ack !== undefined) {
+                                    if (isObject(initValue) && initValue.ack !== undefined) {
                                         adapter.setState(name, initValue, callback);
                                     } else {
                                         adapter.setState(name, initValue, true, callback);
@@ -1809,7 +1825,7 @@ function sandBox(script, name, verbose, debug, context) {
                         hour12: false
                     });
                 }
-            } else if (startTime && typeof startTime === 'object' && startTime.astro) {
+            } else if (startTime && isObject(startTime) && startTime.astro) {
                 startTime = sandbox.getAstroDate(startTime.astro, startTime.date || new Date(), startTime.offset || 0);
                 startTime = startTime.toLocaleTimeString([], {
                     hour:   '2-digit',
@@ -1826,7 +1842,7 @@ function sandBox(script, name, verbose, debug, context) {
                         hour12: false
                     });
                 }
-            } else if (endTime && typeof endTime === 'object' && endTime.astro) {
+            } else if (endTime && isObject(endTime) && endTime.astro) {
                 endTime = sandbox.getAstroDate(endTime.astro, endTime.date || new Date(), endTime.offset || 0);
                 endTime = endTime.toLocaleTimeString([], {
                     hour:   '2-digit',
@@ -1838,7 +1854,7 @@ function sandBox(script, name, verbose, debug, context) {
                 if ((pos = consts.astroListLow.indexOf(time.toLowerCase())) !== -1) {
                     time = sandbox.getAstroDate(consts.astroList[pos]);
                 }
-            } else if (time && typeof time === 'object' && time.astro) {
+            } else if (time && isObject(time) && time.astro) {
                 time = sandbox.getAstroDate(time.astro, time.date || new Date(), time.offset || 0);
             }
 
@@ -1846,7 +1862,7 @@ function sandBox(script, name, verbose, debug, context) {
             if (time) {
                 daily = false;
             }
-            if (time && typeof time !== 'object') {
+            if (time && !isObject(time)) {
                 if (typeof time === 'string' && time.indexOf(' ') === -1 && time.indexOf('T') === -1) {
                     const parts = time.split(':');
                     time = new Date();
@@ -1992,7 +2008,7 @@ function sandBox(script, name, verbose, debug, context) {
         },
 
         getDateObject:  function (date) {
-            if (typeof date === 'object') return date;
+            if (isObject(date)) return date;
             if (typeof date !== 'string') return new Date(date);
             if (date.match(/^\d?\d$/)) {
                 const _now = new Date();
@@ -2069,7 +2085,7 @@ function sandBox(script, name, verbose, debug, context) {
             return sandbox.unlink(_adapter, fileName, callback);
         },
         getHistory:     function (instance, options, callback) {
-            if (typeof instance === 'object') {
+            if (isObject(instance)) {
                 callback = options;
                 options  = instance;
                 instance = null;
@@ -2079,7 +2095,7 @@ function sandBox(script, name, verbose, debug, context) {
                 adapter.log.error('No callback found!');
                 return;
             }
-            if (typeof options !== 'object') {
+            if (!isObject(options)) {
                 adapter.log.error('No options found!');
                 return;
             }

--- a/lib/sandbox.js
+++ b/lib/sandbox.js
@@ -978,9 +978,12 @@ function sandBox(script, name, verbose, debug, context) {
             }
 
             if (isAck === true || isAck === false || isAck === 'true' || isAck === 'false') {
-                if (isObject(state)) {
+                if (isObject(state) && state.val !== undefined) {
+                    // we assume that we were given a state object if
+                    // state is an object that contains a `val` property
                     state.ack = isAck;
                 } else {
+                    // otherwise assume that the given state is the value to be set
                     state = {val: state, ack: isAck};
                 }
             }

--- a/lib/tools.js
+++ b/lib/tools.js
@@ -1,0 +1,25 @@
+/**
+ * Tests whether the given variable is a real object and not an Array
+ * @param {any} it The variable to test
+ */
+function isObject(it) {
+	// This is necessary because:
+	// typeof null === 'object'
+	// typeof [] === 'object'
+	// [] instanceof Object === true
+	return Object.prototype.toString.call(it) === '[object Object]';
+}
+
+/**
+ * Tests whether the given variable is really an Array
+ * @param {any} it The variable to test
+ */
+function isArray(it) {
+	if (Array.isArray != null) return Array.isArray(it);
+	return Object.prototype.toString.call(it) === '[object Array]';
+}
+
+module.exports = {
+	isArray,
+	isObject,
+};


### PR DESCRIPTION
This supersedes #171 and fixes more checks. Thx @paul53 for finding the original issue.

This change is necessary because simply checking `typeof variable` is not enough to determine if something is an object or an array. The most dangerous check is this:
```js
if (typeof state === 'object') {
    // at this point, state is either an object, an Array or null!!!
    state.ack = isAck;
}
```
Another one is using `typeof state.val` to check if a state has the correct `common.type`, which fails if the type is `"array"`, because `typeof [ ] === "object"`.

Thus I replaced all checks where a variable's type is compared with the dedicated checks `isObject` or `isArray` to be 100% sure the variables are of the correct type.