### PR TITLE
Start using generic types for states

### DIFF
--- a/lib/javascript.d.ts
+++ b/lib/javascript.d.ts
@@ -342,7 +342,7 @@ declare global {
 			 * Executes a function for each state id in the result array
 			 * The execution is canceled if a callback returns false
 			 */
-			each: (callback?: (id: string, index: number) => boolean | void) => this;
+			each(callback?: (id: string, index: number) => boolean | void): this;
 
 			/**
 			 * Returns the first state found by this query.
@@ -356,12 +356,12 @@ declare global {
 			/**
 			 * Sets all queried states to the given value.
 			 */
-			setState: <T extends StateValue>(id: string, state: T | State<T> | Partial<State<T>>, ack?: boolean, callback?: SetStateCallback) => this;
+			setState<T extends StateValue>(id: string, state: T | State<T> | Partial<State<T>>, ack?: boolean, callback?: SetStateCallback): this;
 
 			/**
 			 * Subscribes the given callback to changes of the matched states.
 			 */
-			on: (callback: StateChangeHandler) => this;
+			on(callback: StateChangeHandler): this;
 		}
 
 		/**

--- a/lib/javascript.d.ts
+++ b/lib/javascript.d.ts
@@ -23,9 +23,9 @@ declare global {
 			sensor_reports_error = 0x84,
 		}
 
-		interface State {
+		interface State<T = any> {
 			/** The value of the state. */
-			val: any;
+			val: T;
 
 			/** Direction flag: false for desired value and true for actual value. Default: false. */
 			ack: boolean;
@@ -47,6 +47,11 @@ declare global {
 
 			/** Optional comment */
 			c?: string;
+		}
+
+		interface AbsentState {
+			val: null;
+			notExist: true;
 		}
 
 		type ObjectType = "state" | "channel" | "device";
@@ -163,7 +168,7 @@ declare global {
 			common?: Partial<OtherCommon>;
 		}
 		/** Represents the change of a state */
-		interface ChangedStateObject extends StateObject {
+		interface ChangedStateObject<T = any> extends StateObject {
 			common: StateCommon;
 			native: Record<string, any>;
 			id?: string;
@@ -177,11 +182,11 @@ declare global {
 			/** The names of enums this state is assigned to. For example ["Licht","Garten"] */
 			enumNames?: string[];
 			/** new state */
-			state: State;
+			state: State<T>;
 			/** @deprecated Use state instead **/
-			newState: State;
+			newState: State<T>;
 			/** previous state */
-			oldState: State;
+			oldState: State<T>;
 			/** Name of the adapter instance which set the value, e.g. "system.adapter.web.0" */
 			from?: string;
 			/** Unix timestamp. Default: current time */
@@ -195,10 +200,10 @@ declare global {
 		type Object = StateObject | ChannelObject | DeviceObject | OtherObject;
 		type PartialObject = PartialStateObject | PartialChannelObject | PartialDeviceObject | PartialOtherObject;
 
-		type GetStateCallback = (err: string | null, state?: State) => void;
-		type SetStateCallback = (err: string | null, id?: string) => void;
+		type GetStateCallback<T = any> = (err: string | null, state?: State<T>) => void;
+		type SetStateCallback<T = any> = (err: string | null, id?: string) => void;
 
-		type StateChangeHandler = (obj: ChangedStateObject) => void;
+		type StateChangeHandler<T = any> = (obj: ChangedStateObject<T>) => void;
 
 		type SetObjectCallback = (err: string | null, obj: { id: string }) => void;
 		type GetObjectCallback = (err: string | null, obj: iobJS.Object) => void;
@@ -341,17 +346,17 @@ declare global {
 			 * this can be called synchronously and immediately returns the state.
 			 * Otherwise you need to provide a callback.
 			 */
-			getState: (callback?: GetStateCallback) => void | State;
+			getState: <T = any>(callback?: GetStateCallback<T>) => void | State<T> | AbsentState;
 
 			/**
 			 * Sets all queried states to the given value.
 			 */
-			setState: (id: string, state: string | number | boolean | State | Partial<State>, ack?: boolean, callback?: SetStateCallback) => this;
+			setState: <T extends string | number | boolean>(id: string, state: T | State<T> | Partial<State<T>>, ack?: boolean, callback?: SetStateCallback) => this;
 
 			/**
 			 * Subscribes the given callback to changes of the matched states.
 			 */
-			on: (callback: StateChangeHandler) => this;
+			on: <T = any>(callback: StateChangeHandler<T>) => this;
 		}
 
 		/**
@@ -497,7 +502,7 @@ declare global {
 	 * @param message The message to print
 	 * @param severity (optional) severity of the message. default = "info"
 	 */
-	function log(message: string, severity?: iobJS.LogLevel);
+	function log(message: string, severity?: iobJS.LogLevel): void;
 
 	// TODO: Do we need this?
 	// namespace console {
@@ -556,18 +561,18 @@ declare global {
 	/**
 	 * Subscribe to changes of the matched states.
 	 */
-	function on(pattern: string | RegExp | string[], handler: iobJS.StateChangeHandler): any;
-	function on(
+	function on<T = any>(pattern: string | RegExp | string[], handler: iobJS.StateChangeHandler<T>): any;
+	function on<T = any>(
 		astroOrScheduleOrOptions: iobJS.AstroSchedule | iobJS.SubscribeTime | iobJS.SubscribeOptions, 
-		handler: iobJS.StateChangeHandler
+		handler: iobJS.StateChangeHandler<T>
 	): any;
 	/**
 	 * Subscribe to changes of the matched states.
 	 */
-	function subscribe(pattern: string | RegExp | string[], handler: iobJS.StateChangeHandler): any;
-	function subscribe(
+	function subscribe<T = any>(pattern: string | RegExp | string[], handler: iobJS.StateChangeHandler<T>): any;
+	function subscribe<T = any>(
 		astroOrScheduleOrOptions: iobJS.AstroSchedule | iobJS.SubscribeTime | iobJS.SubscribeOptions, 
-		handler: iobJS.StateChangeHandler
+		handler: iobJS.StateChangeHandler<T>
 	): any;
 
 	/**
@@ -643,8 +648,8 @@ declare global {
 	 * this can be called synchronously and immediately returns the state.
 	 * Otherwise you need to provide a callback.
 	 */
-	function getState(id: string, callback: iobJS.GetStateCallback): void;
-	function getState(id: string): iobJS.State;
+	function getState<T = any>(id: string, callback: iobJS.GetStateCallback<T>): void;
+	function getState<T = any>(id: string): iobJS.State<T>;
 
 	/**
 	 * Checks if the state with the given ID exists
@@ -777,13 +782,14 @@ declare global {
 	 * Starts or restarts a script by name
 	 * @param scriptName (optional) Name of the script. If none is given, the current script is (re)started.
 	 */
-	function startScript(scriptName, ignoreIfStarted, callback?: GenericCallback<boolean>): boolean;
+	function startScript(scriptName?: string, ignoreIfStarted?: boolean, callback?: GenericCallback<boolean>): boolean;
+	function startScript(scriptName?: string, callback?: GenericCallback<boolean>): boolean;
 	/**
 	 * Stops a script by name
 	 * @param scriptName (optional) Name of the script. If none is given, the current script is stopped.
 	 */
-	function stopScript(scriptName, callback?: GenericCallback<boolean>): boolean;
-	function isScriptActive(scriptName): boolean;
+	function stopScript(scriptName: string, callback?: GenericCallback<boolean>): boolean;
+	function isScriptActive(scriptName: string): boolean;
 
 	/** Converts a value to an integer */
 	function toInt(val: any): number;

--- a/lib/javascript.d.ts
+++ b/lib/javascript.d.ts
@@ -23,7 +23,7 @@ declare global {
 			sensor_reports_error = 0x84,
 		}
 
-		interface State<T extends StateValue = any> {
+		interface State<T extends StateValue = StateValue> {
 			/** The value of the state. */
 			val: T;
 
@@ -49,13 +49,9 @@ declare global {
 			c?: string;
 		}
 
-		type ObjectTypeStateValue = Record<string, any>;
-
 		type PrimitiveTypeStateValue = string | number | boolean;
 
-		type ArrayTypeStateValue = Array<PrimitiveTypeStateValue>;
-
-		type StateValue = ObjectTypeStateValue | ArrayTypeStateValue;
+		type StateValue = PrimitiveTypeStateValue | PrimitiveTypeStateValue[] | Record<string, any>;
 
 		interface AbsentState {
 			val: null;
@@ -176,7 +172,7 @@ declare global {
 			common?: Partial<OtherCommon>;
 		}
 		/** Represents the change of a state */
-		interface ChangedStateObject<TOld extends StateValue = any, TNew extends StateValue = any> extends StateObject {
+		interface ChangedStateObject<TOld extends StateValue = any, TNew extends StateValue = TOld> extends StateObject {
 			common: StateCommon;
 			native: Record<string, any>;
 			id?: string;
@@ -354,7 +350,8 @@ declare global {
 			 * this can be called synchronously and immediately returns the state.
 			 * Otherwise you need to provide a callback.
 			 */
-			getState: (<T = any>(callback: GetStateCallback<T>) => void) | (<T = any>() => State<T> | null | undefined);
+			getState<T = any>(callback: GetStateCallback<T>): void;
+			getState<T = any>(): State<T> | null | undefined;
 
 			/**
 			 * Sets all queried states to the given value.
@@ -626,8 +623,8 @@ declare global {
 	 * Sets a state to the given value
 	 * @param id The ID of the state to be set
 	 */
-	function setState<T extends iobJS.StateValue>(id: string, state: T, callback?: iobJS.SetStateCallback): void;
-	function setState<T extends iobJS.StateValue>(id: string, state: T, ack: boolean, callback?: iobJS.SetStateCallback): void;
+	function setState<T extends iobJS.StateValue>(id: string, state: T | iobJS.State<T> | Partial<iobJS.State<T>>, callback?: iobJS.SetStateCallback): void;
+	function setState<T extends iobJS.StateValue>(id: string, state: T | iobJS.State<T> | Partial<iobJS.State<T>>, ack: boolean, callback?: iobJS.SetStateCallback): void;
 
 	/**
 	 * Sets a state to the given value after a timeout has passed.
@@ -657,7 +654,7 @@ declare global {
 	 * Otherwise you need to provide a callback.
 	 */
 	function getState<T extends iobJS.StateValue = any>(id: string, callback: iobJS.GetStateCallback<T>): void;
-	function getState<T extends iobJS.StateValue = any>(id: string): iobJS.State<T>;
+	function getState<T extends iobJS.StateValue = any>(id: string): iobJS.State<T> | iobJS.AbsentState;
 
 	/**
 	 * Checks if the state with the given ID exists

--- a/lib/javascript.d.ts
+++ b/lib/javascript.d.ts
@@ -51,7 +51,7 @@ declare global {
 
 		type PrimitiveTypeStateValue = string | number | boolean;
 
-		type StateValue = PrimitiveTypeStateValue | PrimitiveTypeStateValue[] | Record<string, any>;
+		type StateValue = null | PrimitiveTypeStateValue | PrimitiveTypeStateValue[] | Record<string, any>;
 
 		interface AbsentState {
 			val: null;
@@ -77,6 +77,7 @@ declare global {
 			role?: string;
 		}
 
+		// TODO: def can be further restricted depending on the object type
 		interface StateCommon extends ObjectCommon {
 			/** Type of this state. See https://github.com/ioBroker/ioBroker/blob/master/doc/SCHEMA.md#state-commonrole for a detailed description */
 			type?: CommonType;
@@ -87,7 +88,7 @@ declare global {
 			/** unit of the value */
 			unit?: string;
 			/** the default value */
-			def?: any;
+			def?: StateValue;
 			/** description of this state */
 			desc?: string;
 
@@ -172,7 +173,7 @@ declare global {
 			common?: Partial<OtherCommon>;
 		}
 		/** Represents the change of a state */
-		interface ChangedStateObject<TOld extends StateValue = any, TNew extends StateValue = TOld> extends StateObject {
+		interface ChangedStateObject<TOld extends StateValue = StateValue, TNew extends StateValue = TOld> extends StateObject {
 			common: StateCommon;
 			native: Record<string, any>;
 			id?: string;
@@ -204,7 +205,7 @@ declare global {
 		type Object = StateObject | ChannelObject | DeviceObject | OtherObject;
 		type PartialObject = PartialStateObject | PartialChannelObject | PartialDeviceObject | PartialOtherObject;
 
-		type GetStateCallback<T = any> = (err: string | null, state?: State<T> | AbsentState) => void;
+		type GetStateCallback<T extends StateValue> = (err: string | null, state?: State<T> | AbsentState) => void;
 		type SetStateCallback = (err: string | null, id?: string) => void;
 
 		type StateChangeHandler= (obj: ChangedStateObject) => void;
@@ -243,31 +244,31 @@ declare global {
 			name?: string | string[] | RegExp;
 			/** type of change */
 			change?: "eq" | "ne" | "gt" | "ge" | "lt" | "le" | "any";
-			val?: any;
+			val?: StateValue;
 			/** New value must not be equal to given one */
-			valNe?: any;
+			valNe?: StateValue;
 			/** New value must be greater than given one */
-			valGt?: any;
+			valGt?: number;
 			/** New value must be greater or equal to given one */
-			valGe?: any;
+			valGe?: number;
 			/** New value must be smaller than given one */
-			valLt?: any;
+			valLt?: number;
 			/** New value must be smaller or equal to given one */
-			valLe?: any;
+			valLe?: number;
 			/** Acknowledged state of new value is equal to given one */
 			ack?: boolean;
 			/** Previous value must be equal to given one */
-			oldVal?: any;
+			oldVal?: StateValue;
 			/** Previous value must be not equal to given one */
-			oldValNe?: any;
+			oldValNe?: StateValue;
 			/** Previous value must be greater than given one */
-			oldValGt?: any;
+			oldValGt?: number;
 			/** Previous value must be greater or equal given one */
-			oldValGe?: any;
+			oldValGe?: number;
 			/** Previous value must be smaller than given one */
-			oldValLt?: any;
+			oldValLt?: number;
 			/** Previous value must be smaller or equal to given one */
-			oldValLe?: any;
+			oldValLe?: number;
 			/** Acknowledged state of previous value is equal to given one */
 			oldAck?: boolean;
 			/** New value time stamp must be equal to given one (state.ts == ts) */
@@ -350,8 +351,8 @@ declare global {
 			 * this can be called synchronously and immediately returns the state.
 			 * Otherwise you need to provide a callback.
 			 */
-			getState<T = any>(callback: GetStateCallback<T>): void;
-			getState<T = any>(): State<T> | null | undefined;
+			getState<T extends StateValue = StateValue>(callback: GetStateCallback<T>): void;
+			getState<T extends StateValue = StateValue>(): State<T> | null | undefined;
 
 			/**
 			 * Sets all queried states to the given value.
@@ -633,12 +634,12 @@ declare global {
 	 * @param delay The delay in milliseconds
 	 * @param clearRunning (optional) Whether an existing timeout for this state should be cleared
 	 */
-	function setStateDelayed(id: string, state: string | number | boolean | iobJS.State | Partial<iobJS.State>, delay: number, clearRunning: boolean, callback?: iobJS.SetStateCallback): any;
-	function setStateDelayed(id: string, state: string | number | boolean | iobJS.State | Partial<iobJS.State>, ack: boolean, clearRunning: boolean, callback?: iobJS.SetStateCallback): any;
-	function setStateDelayed(id: string, state: string | number | boolean | iobJS.State | Partial<iobJS.State>, ack: boolean, delay: number, callback?: iobJS.SetStateCallback): any;
-	function setStateDelayed(id: string, state: string | number | boolean | iobJS.State | Partial<iobJS.State>, delay: number, callback?: iobJS.SetStateCallback): any;
-	function setStateDelayed(id: string, state: string | number | boolean | iobJS.State | Partial<iobJS.State>, callback?: iobJS.SetStateCallback): any;
-	function setStateDelayed(id: string, state: string | number | boolean | iobJS.State | Partial<iobJS.State>, ack: boolean, delay: number, clearRunning: boolean, callback?: iobJS.SetStateCallback): any;
+	function setStateDelayed<T extends iobJS.StateValue>(id: string, state: T | iobJS.State<T> | Partial<iobJS.State<T>>, delay: number, clearRunning: boolean, callback?: iobJS.SetStateCallback): any;
+	function setStateDelayed<T extends iobJS.StateValue>(id: string, state: T | iobJS.State<T> | Partial<iobJS.State<T>>, ack: boolean, clearRunning: boolean, callback?: iobJS.SetStateCallback): any;
+	function setStateDelayed<T extends iobJS.StateValue>(id: string, state: T | iobJS.State<T> | Partial<iobJS.State<T>>, ack: boolean, delay: number, callback?: iobJS.SetStateCallback): any;
+	function setStateDelayed<T extends iobJS.StateValue>(id: string, state: T | iobJS.State<T> | Partial<iobJS.State<T>>, delay: number, callback?: iobJS.SetStateCallback): any;
+	function setStateDelayed<T extends iobJS.StateValue>(id: string, state: T | iobJS.State<T> | Partial<iobJS.State<T>>, callback?: iobJS.SetStateCallback): any;
+	function setStateDelayed<T extends iobJS.StateValue>(id: string, state: T | iobJS.State<T> | Partial<iobJS.State<T>>, ack: boolean, delay: number, clearRunning: boolean, callback?: iobJS.SetStateCallback): any;
 
 	/**
 	 * Clears a timer created by setStateDelayed
@@ -653,8 +654,8 @@ declare global {
 	 * this can be called synchronously and immediately returns the state.
 	 * Otherwise you need to provide a callback.
 	 */
-	function getState<T extends iobJS.StateValue = any>(id: string, callback: iobJS.GetStateCallback<T>): void;
-	function getState<T extends iobJS.StateValue = any>(id: string): iobJS.State<T> | iobJS.AbsentState;
+	function getState<T extends iobJS.StateValue = iobJS.StateValue>(id: string, callback: iobJS.GetStateCallback<T>): void;
+	function getState<T extends iobJS.StateValue = iobJS.StateValue>(id: string): iobJS.State<T> | iobJS.AbsentState;
 
 	/**
 	 * Checks if the state with the given ID exists
@@ -692,14 +693,14 @@ declare global {
 	 * @param callback (optional) Called after the state was created
 	 */
 	function createState(name: string, callback?: iobJS.SetStateCallback): void;
-	function createState(name: string, initValue: any, callback?: iobJS.SetStateCallback): void;
-	function createState(name: string, initValue: any, forceCreation: boolean, callback?: iobJS.SetStateCallback): void;
-	function createState(name: string, initValue: any, forceCreation: boolean, common: Partial<iobJS.StateCommon>, callback?: iobJS.SetStateCallback): void;
-	function createState(name: string, initValue: any, forceCreation: boolean, common: Partial<iobJS.StateCommon>, native: any, callback?: iobJS.SetStateCallback): void;
+	function createState(name: string, initValue: iobJS.StateValue, callback?: iobJS.SetStateCallback): void;
+	function createState(name: string, initValue: iobJS.StateValue, forceCreation: boolean, callback?: iobJS.SetStateCallback): void;
+	function createState(name: string, initValue: iobJS.StateValue, forceCreation: boolean, common: Partial<iobJS.StateCommon>, callback?: iobJS.SetStateCallback): void;
+	function createState(name: string, initValue: iobJS.StateValue, forceCreation: boolean, common: Partial<iobJS.StateCommon>, native: any, callback?: iobJS.SetStateCallback): void;
 	function createState(name: string, common: Partial<iobJS.StateCommon>, callback?: iobJS.SetStateCallback): void;
-	function createState(name: string, initValue: any, common: Partial<iobJS.StateCommon>, callback?: iobJS.SetStateCallback): void;
+	function createState(name: string, initValue: iobJS.StateValue, common: Partial<iobJS.StateCommon>, callback?: iobJS.SetStateCallback): void;
 	function createState(name: string, common: Partial<iobJS.StateCommon>, native: any, callback?: iobJS.SetStateCallback): void;
-	function createState(name: string, initValue: any, common: Partial<iobJS.StateCommon>, native: any, callback?: iobJS.SetStateCallback): void;
+	function createState(name: string, initValue: iobJS.StateValue, common: Partial<iobJS.StateCommon>, native: any, callback?: iobJS.SetStateCallback): void;
 
 	/**
 	 * Deletes the state with the given ID


### PR DESCRIPTION
Start using generic types for state values and their respective handler (in a backwards-compatible way).

This makes handling with states more type-safe. 

```typescript
subscribe<boolean>(pattern: "some.id", ({state}) => {state.val.subString(0,1)});
```

The above example will not compile, since `state.val` is now a boolean.