### PR TITLE
Add one-time subscriptions with the `once` method

### DIFF
--- a/lib/javascript.d.ts
+++ b/lib/javascript.d.ts
@@ -350,6 +350,8 @@ declare global {
 			[index: number]: string;
 			/** Number of matched states */
 			length: number;
+			/** Contains the error if one happened */
+			error?: string;
 
 			/**
 			 * Executes a function for each state id in the result array
@@ -582,6 +584,17 @@ declare global {
 		astroOrScheduleOrOptions: iobJS.AstroSchedule | iobJS.SubscribeTime | iobJS.SubscribeOptions, 
 		handler: iobJS.StateChangeHandler
 	): any;
+
+	/**
+	 * Registers a one-time subscription which automatically unsubscribes after the first invocation
+	 */
+	function once(
+		pattern: string | RegExp | string[] | iobJS.AstroSchedule | iobJS.SubscribeTime | iobJS.SubscribeOptions,
+		handler: iobJS.StateChangeHandler
+	): any;
+	function once(
+		pattern: string | RegExp | string[] | iobJS.AstroSchedule | iobJS.SubscribeTime | iobJS.SubscribeOptions
+	): Promise<iobJS.ChangedStateObject>;
 
 	/**
 	 * Causes all changes of the state with id1 to the state with id2.

--- a/lib/sandbox.js
+++ b/lib/sandbox.js
@@ -269,6 +269,7 @@ function sandBox(script, name, verbose, debug, context) {
 
             // Todo CACHE!!!
 
+            /** @type {iobJS.QueryResult} */
             const result  = {};
 
             let name      = '';
@@ -855,6 +856,25 @@ function sandBox(script, name, verbose, debug, context) {
         },
         on:             function (pattern, callbackOrId, value) {
             return sandbox.subscribe(pattern, callbackOrId, value);
+        },
+        /** Registers a one-time subscription which automatically unsubscribes after the first invocation */
+        once: function (pattern, callback) {
+            function _once(cb) {
+                // Callback-style: once("id", (obj) => { ... })
+                /** @type {iobJS.StateChangeHandler} */
+                const handler = (obj) => {
+                    sandbox.unsubscribe(subscription);
+                    typeof cb === 'function' && cb(obj);
+                };
+                const subscription = sandbox.subscribe(pattern, handler);
+                return subscription;
+            }
+            if (callback != undefined) {
+                return _once(callback);
+            } else {
+                // Promise-style: once("id").then(obj => { ... })
+                return new Promise(resolve => _once(resolve));
+            }
         },
         schedule:       function (pattern, callback) {
             if (typeof callback !== 'function') {

--- a/lib/sandbox.js
+++ b/lib/sandbox.js
@@ -860,7 +860,6 @@ function sandBox(script, name, verbose, debug, context) {
         /** Registers a one-time subscription which automatically unsubscribes after the first invocation */
         once: function (pattern, callback) {
             function _once(cb) {
-                // Callback-style: once("id", (obj) => { ... })
                 /** @type {iobJS.StateChangeHandler} */
                 const handler = (obj) => {
                     sandbox.unsubscribe(subscription);
@@ -870,6 +869,7 @@ function sandBox(script, name, verbose, debug, context) {
                 return subscription;
             }
             if (callback != undefined) {
+                // Callback-style: once("id", (obj) => { ... })
                 return _once(callback);
             } else {
                 // Promise-style: once("id").then(obj => { ... })


### PR DESCRIPTION
Fixes: #254 

Example code:
```js
// promise-style:
once("id").then(obj => { ... });

// callback-style:
once("id", obj => { ... });
```

The subscriptions are automatically unsubscribed after they are invoked.