### PR TITLE
Fix a bunch of issues found by lgtm.com

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,7 +1,8 @@
 {
     "env": {
         "es6": true,
-        "node": true
+        "node": true,
+        "mocha": true
     },
     "extends": "eslint:recommended",
     "rules": {

--- a/lib/convert.js
+++ b/lib/convert.js
@@ -23,9 +23,6 @@ function stringify(data) {
         } else {
             obj = JSON.stringify(obj, null, 2);
         }
-    } else if (data.data.type === 'script') {
-        id = id.replace(/\./g, '/').substring('script.js.'.length) + '.json';
-        obj = JSON.stringify(obj, null, 2);
     }
 
     return {id: id, data: obj};

--- a/lib/sandbox.js
+++ b/lib/sandbox.js
@@ -1280,8 +1280,6 @@ function sandBox(script, name, verbose, debug, context) {
                 id = adapter.namespace + '.' + id;
             }
 
-            if (clearRunning === undefined) clearRunning = true;
-
             sandbox.verbose && sandbox.log('setStateDelayed(id=' + id + ', state=' + state + ', isAck=' + isAck + ', delay=' + delay + ', clearRunning=' + clearRunning + ')', 'info');
 
             if (clearRunning) {

--- a/lib/scheduler.js
+++ b/lib/scheduler.js
@@ -159,7 +159,7 @@ class Scheduler {
                     return;
                 }
                 if (schedule.period.years > 1) {
-                    const diff = Math.floor(this.monthDiff(this.period.fromDate, new Date(context.now)) / 12);
+                    const diff = Math.floor(this.monthDiff(schedule.period.fromDate, new Date(context.now)) / 12);
                     if (diff % schedule.period.years) {
                         return;
                     }
@@ -200,12 +200,7 @@ class Scheduler {
         } else {
             d = new Date(parseInt(parts[2], 10), parseInt(parts[1], 10) - 1, parseInt(parts[0], 10));
         }
-        if (d) {
-            return {y: d.getFullYear(), m: d.getMonth(), d: d.getDate()};
-        } else {
-            this.log.warn('Invalid date: ' + date);
-            return null;
-        }
+        return {y: d.getFullYear(), m: d.getMonth(), d: d.getDate()};
     }
 
     isPast(context, date) {

--- a/main.js
+++ b/main.js
@@ -1019,7 +1019,7 @@ function unsubscribe(id) {
         return;
     }
 
-    if (typeof id === 'object' && id && id.constructor && id.constructor.name === 'RegExp') {
+    if (id.constructor && id.constructor.name === 'RegExp') {
         //adapter.log.warn('unsubscribe: todo - process regexp');
         return;
     }

--- a/src/src/Components/simple-cron/SimpleCron.js
+++ b/src/src/Components/simple-cron/SimpleCron.js
@@ -101,7 +101,7 @@ class SimpleCron extends React.Component {
     static periodArray2text(list, max) {
         max = max || 7;
         if (list.length === max) {
-            return '*'
+            return '*';
         } else {
             let text = [];
             let start = null;
@@ -327,7 +327,7 @@ class SimpleCron extends React.Component {
             settings.timeFrom = settings.timeFrom || 0;
             settings.timeTo = settings.timeTo === undefined ? 24 : settings.timeTo;
             if (settings.timeFrom === 0 && settings.timeTo === 24) {
-                hours = '*'
+                hours = '*';
             } else {
                 hours = settings.timeFrom !== settings.timeTo ? settings.timeFrom + '-' + settings.timeTo : '*';
             }

--- a/src/src/Components/simple-cron/cronText.js
+++ b/src/src/Components/simple-cron/cronText.js
@@ -38,7 +38,6 @@ function correctCasus(text, seconds) {
     text = text.replace(/Jede\(r\) ([\d\sund,]+) Sekunde/, 'Jede $1 Sekunde');
     text = text.replace('Jede(r) Minute',       'Jede Minute');
     text = text.replace('Jede Minuten',         'Jede Minute');
-    text = text.replace('Jede Stunde',          'Jede Stunde');
     text = text.replace('Jede(r) Stunde',       'Jede Stunde');
     text = text.replace(/Jede\(r\) ([\d\sund,]+) Minute/, 'Jede $1 Minute');
     text = text.replace('Jede Sekunde in Minuten', 'Jede Sekunde in jeder Minute');

--- a/src/src/Connection.js
+++ b/src/src/Connection.js
@@ -14,7 +14,7 @@ class Connection {
         this.autoSubscribes = this.props.autoSubscribes || [];
         this.autoSubscribeLog = this.props.autoSubscribeLog;
         this.socket = window.io.connect(
-            window.location.protocol + '//' + window.location.host.replace('3000', 8081),
+            window.location.protocol + '//' + window.location.host.replace('3000', '8081'),
             {query: 'ws=true'});
         this.states = {};
         this.objects = null;
@@ -92,7 +92,7 @@ class Connection {
             this.onError({message: 'no permission', operation: err.operation, type: err.type, id: (err.id || '')}));
 
         this.socket.on('objectChange', (id, obj) => setTimeout(() => this.objectChange(id, obj), 0));
-        this.socket.on('stateChange', (id, state) => setTimeout(() => this.stateChange(id, state), 0))
+        this.socket.on('stateChange', (id, state) => setTimeout(() => this.stateChange(id, state), 0));
     }
 
     subscribeState(id, cb) {

--- a/src/src/Editor.js
+++ b/src/src/Editor.js
@@ -370,7 +370,7 @@ class Editor extends React.Component {
                         if (this.state.editing.indexOf(id) !== -1) {
                             const editing = JSON.parse(JSON.stringify(this.state.editing));
                             const pos = editing.indexOf(id);
-                            if (id !== -1) {
+                            if (pos !== -1) {
                                 editing.splice(pos, 1);
                                 newState.editing = editing;
                                 _changed = true;

--- a/src/src/SideMenu.js
+++ b/src/src/SideMenu.js
@@ -192,7 +192,7 @@ const prepareList = data => {
         } else {
             // common and global are always at the end
             if ((a.id.startsWith('script.js.common') || a.id.startsWith('script.js.global')) &&
-                (a.id.startsWith('script.js.common') || a.id.startsWith('script.js.global'))) {
+                (b.id.startsWith('script.js.common') || b.id.startsWith('script.js.global'))) {
                 if (a.id === b.id) return 0;
                 return a.id > b.id ? 1 : -1;
             } else if (a.id.startsWith('script.js.common') || a.id.startsWith('script.js.global')) {
@@ -360,7 +360,7 @@ class SideDrawer extends React.Component {
         if (!noUpdate && changed) {
             this.setState(newState, () => cb && cb());
         } else {
-            cb && cb()
+            cb && cb();
         }
     }
 

--- a/src/src/createTheme.js
+++ b/src/src/createTheme.js
@@ -1,5 +1,4 @@
 import {createMuiTheme} from '@material-ui/core/styles';
-import Theme from './Theme';
 
 export default type => {
     if (type === 'dark') {

--- a/test/testFunctions.js
+++ b/test/testFunctions.js
@@ -1,8 +1,8 @@
-var expect = require('chai').expect;
-var setup  = require(__dirname + '/lib/setup');
+const expect = require('chai').expect;
+const setup  = require(__dirname + '/lib/setup');
 
-var objects = null;
-var states  = null;
+let objects = null;
+let states  = null;
 
 const stateChangedHandlers = new Set();
 function onStateChanged(id, state) {
@@ -88,7 +88,7 @@ describe('Test JS', function() {
         this.timeout(600000); // because of first install from npm
 
         setup.setupController(function () {
-            var config = setup.getAdapterConfig();
+            const config = setup.getAdapterConfig();
             // enable adapter
             config.common.enabled  = true;
             config.common.loglevel = 'debug';
@@ -99,39 +99,39 @@ describe('Test JS', function() {
             setup.setAdapterConfig(config.common, config.native);
 
             setup.startController(false, function (id, obj) {
-                    if (onObjectChanged) onObjectChanged(id, obj);
-                }, function (id, state) {
-                    if (onStateChanged) onStateChanged(id, state);
+                if (onObjectChanged) onObjectChanged(id, obj);
+            }, function (id, state) {
+                if (onStateChanged) onStateChanged(id, state);
             },
             function (_objects, _states) {
                 objects = _objects;
                 states  = _states;
                 states.subscribe('*');
-                var script = {
-                    "common": {
-                        "name":         "new script global",
-                        "engineType":   "Javascript/js",
-                        "source":       "function setTestState(val) {\ncreateState('testGlobal', val, function () {\nsetState('testGlobal', val);\n});\n}",
-                        "enabled":      true,
-                        "engine":       "system.adapter.javascript.0"
+                let script = {
+                    'common': {
+                        'name':         'new script global',
+                        'engineType':   'Javascript/js',
+                        'source':       "function setTestState(val) {\ncreateState('testGlobal', val, function () {\nsetState('testGlobal', val);\n});\n}",
+                        'enabled':      true,
+                        'engine':       'system.adapter.javascript.0'
                     },
-                    "type":             "script",
-                    "_id":              "script.js.global.TestGlobalNew.Script",
-                    "native": {}
+                    'type':             'script',
+                    '_id':              'script.js.global.TestGlobalNew.Script',
+                    'native': {}
                 };
                 objects.setObject(script._id, script, function (err) {
                     expect(err).to.be.not.ok;
                     script = {
-                        "common": {
-                            "name": "Old script global",
-                            "engineType": "Javascript/js",
-                            "source": "function setTestStateOld(val) {\ncreateState('testGlobalOld', val, function () {\nsetState('testGlobalOld', val);\n});\n}",
-                            "enabled": true,
-                            "engine": "system.adapter.javascript.0"
+                        'common': {
+                            'name': 'Old script global',
+                            'engineType': 'Javascript/js',
+                            'source': "function setTestStateOld(val) {\ncreateState('testGlobalOld', val, function () {\nsetState('testGlobalOld', val);\n});\n}",
+                            'enabled': true,
+                            'engine': 'system.adapter.javascript.0'
                         },
-                        "type": "script",
-                        "_id": "script.js.global.TestGlobalOld.Script",
-                        "native": {}
+                        'type': 'script',
+                        '_id': 'script.js.global.TestGlobalOld.Script',
+                        'native': {}
                     };
                     objects.setObject(script._id, script, function (err) {
                         expect(err).to.be.not.ok;
@@ -152,13 +152,13 @@ describe('Test JS', function() {
     it('Test JS: check compareTime between', function (done) {
         this.timeout(10000);
         // add script
-        var script = {
-            "common": {
-                "name":         "check compareTime",
-                "engineType":   "Javascript/js",
-                "source":       "createState('test10', 0, function () {\n" +
-                "   var count = 0;\n" +
-/*                "   var date1 = new Date();\n" +
+        const script = {
+            'common': {
+                'name':         'check compareTime',
+                'engineType':   'Javascript/js',
+                'source':       "createState('test10', 0, function () {\n" +
+                '   var count = 0;\n' +
+                /*                "   var date1 = new Date();\n" +
                 "   date1.setHours(23);\n" +
                 "   date1.setMinutes(30);\n" +
                 "   var date2 = new Date();\n" +
@@ -172,24 +172,24 @@ describe('Test JS', function() {
                 "   count += compareTime('10:00', '20:00', 'between', '15:00') ? 1 : 0;\n" +
                 "   count += compareTime('10:00', '20:00', 'between', '9:00') ? 0 : 1;\n" +
                 "   count += compareTime('10:00', null, '<', '9:00') ? 1 : 0;\n" +
-                "   var date1 = new Date();\n" +
-                "   date1.setHours(10);\n" +
-                "   date1.setMinutes(0);\n" +
+                '   var date1 = new Date();\n' +
+                '   date1.setHours(10);\n' +
+                '   date1.setMinutes(0);\n' +
                 "   count += compareTime(date1, null, '<', '9:00') ? 1 : 0;\n" +
                 "   count += compareTime(date1, '20:00', 'between', '15:00') ? 1 : 0;\n" +
                 "   count += compareTime('5:00', date1, 'between', '8:00') ? 1 : 0;\n" +
-                "   var date2 = new Date(new Date().getTime()+ 24*60*60*1000);\n" +
-                "   date2.setHours(2);\n" +
-                "   date2.setMinutes(30);\n" +
+                '   var date2 = new Date(new Date().getTime()+ 24*60*60*1000);\n' +
+                '   date2.setHours(2);\n' +
+                '   date2.setMinutes(30);\n' +
                 "   count += compareTime('23:00', '01:00', 'between', date2) ? 0 : 1;\n" +
                 "   setState('test10', count);\n" +
-                "});",
-                "enabled":      true,
-                "engine":       "system.adapter.javascript.0"
+                '});',
+                'enabled':      true,
+                'engine':       'system.adapter.javascript.0'
             },
-            "type":             "script",
-            "_id":              "script.js.check_compareTime",
-            "native": {}
+            'type':             'script',
+            '_id':              'script.js.check_compareTime',
+            'native': {}
         };
         const onStateChanged = function (id, state) {
             if (id === 'javascript.0.test10') {
@@ -216,22 +216,22 @@ describe('Test JS', function() {
     it('Test JS: Catch request error', function (done) {
         this.timeout(10000);
         // add script
-        var script = {
-            "common": {
-                "name":         "Catch request error",
-                "engineType":   "Javascript/js",
-                "source":       "var request = require('request');" +
+        const script = {
+            'common': {
+                'name':         'Catch request error',
+                'engineType':   'Javascript/js',
+                'source':       "var request = require('request');" +
                                 "createState('check_request_error', function () {" +
                                 "   request('http://google1456.com').on('error', function (error) { " +
                                 "       console.error(error); setState('check_request_error', true, true);" +
-                                "   });" +
-                                "});",
-                "enabled":      true,
-                "engine":       "system.adapter.javascript.0"
+                                '   });' +
+                                '});',
+                'enabled':      true,
+                'engine':       'system.adapter.javascript.0'
             },
-            "type":             "script",
-            "_id":              "script.js.check_request_error",
-            "native": {}
+            'type':             'script',
+            '_id':              'script.js.check_request_error',
+            'native': {}
         };
         const onStateChanged = function (id, state) {
             if (id === 'javascript.0.check_request_error' && state.val === true) {
@@ -249,17 +249,17 @@ describe('Test JS', function() {
     it('Test JS: check creation of state', function (done) {
         this.timeout(2000);
         // add script
-        var script = {
-            "common": {
-                "name":         "check creation of state",
-                "engineType":   "Javascript/js",
-                "source":       "createState('test1', 5);",
-                "enabled":      true,
-                "engine":       "system.adapter.javascript.0"
+        const script = {
+            'common': {
+                'name':         'check creation of state',
+                'engineType':   'Javascript/js',
+                'source':       "createState('test1', 5);",
+                'enabled':      true,
+                'engine':       'system.adapter.javascript.0'
             },
-            "type":             "script",
-            "_id":              "script.js.check_creation_of_state",
-            "native": {}
+            'type':             'script',
+            '_id':              'script.js.check_creation_of_state',
+            'native': {}
         };
         const onStateChanged = function (id, state) {
             if (id === 'javascript.0.test1' && state.val === 5) {
@@ -285,17 +285,17 @@ describe('Test JS', function() {
     it('Test JS: check creation of state for other instance', function (done) {
         this.timeout(2000);
         // add script
-        var script = {
-            "common": {
-                "name":         "check creation of state",
-                "engineType":   "Javascript/js",
-                "source":       "createState('javascript.1.test1', 6);",
-                "enabled":      true,
-                "engine":       "system.adapter.javascript.0"
+        const script = {
+            'common': {
+                'name':         'check creation of state',
+                'engineType':   'Javascript/js',
+                'source':       "createState('javascript.1.test1', 6);",
+                'enabled':      true,
+                'engine':       'system.adapter.javascript.0'
             },
-            "type":             "script",
-            "_id":              "script.js.check_creation_of_foreign_state",
-            "native": {}
+            'type':             'script',
+            '_id':              'script.js.check_creation_of_foreign_state',
+            'native': {}
         };
         const onStateChanged = function (id, state) {
             if (id === 'javascript.1.test1' && state.val === 6) {
@@ -321,17 +321,17 @@ describe('Test JS', function() {
     it('Test JS: check deletion of state', function (done) {
         this.timeout(2000);
         // add script
-        var script = {
-            "common": {
-                "name":         "check deletion of state",
-                "engineType":   "Javascript/js",
-                "source":       "deleteState('test1');",
-                "enabled":      true,
-                "engine":       "system.adapter.javascript.0"
+        const script = {
+            'common': {
+                'name':         'check deletion of state',
+                'engineType':   'Javascript/js',
+                'source':       "deleteState('test1');",
+                'enabled':      true,
+                'engine':       'system.adapter.javascript.0'
             },
-            "type":             "script",
-            "_id":              "script.js.check_deletion_of_state",
-            "native": {}
+            'type':             'script',
+            '_id':              'script.js.check_deletion_of_state',
+            'native': {}
         };
 
         objects.getObject('javascript.0.test1', function (err, obj) {
@@ -368,17 +368,17 @@ describe('Test JS', function() {
     it('Test JS: check deletion of foreign state', function (done) {
         this.timeout(2000);
         // add script
-        var script = {
-            "common": {
-                "name":         "check deletion of state",
-                "engineType":   "Javascript/js",
-                "source":       "deleteState('javascript.1.test1');",
-                "enabled":      true,
-                "engine":       "system.adapter.javascript.0"
+        const script = {
+            'common': {
+                'name':         'check deletion of state',
+                'engineType':   'Javascript/js',
+                'source':       "deleteState('javascript.1.test1');",
+                'enabled':      true,
+                'engine':       'system.adapter.javascript.0'
             },
-            "type":             "script",
-            "_id":              "script.js.check_deletion_of_foreign_state",
-            "native": {}
+            'type':             'script',
+            '_id':              'script.js.check_deletion_of_foreign_state',
+            'native': {}
         };
 
         objects.getObject('javascript.1.test1', function (err, obj) {
@@ -413,17 +413,17 @@ describe('Test JS', function() {
     it('Test JS: open objects.json file must not work', function (done) {
         this.timeout(20000);
         // add script
-        var script = {
-            "common": {
-                "name":         "open objects",
-                "engineType":   "Javascript/js",
-                "source":       "var fs=require('fs'); try{fs.readFileSync('" + __dirname + "/../tmp/" + setup.appName + "-data/objects.json');}catch(err){createState('error', err.toString());}",
-                "enabled":      true,
-                "engine":       "system.adapter.javascript.0"
+        const script = {
+            'common': {
+                'name':         'open objects',
+                'engineType':   'Javascript/js',
+                'source':       "var fs=require('fs'); try{fs.readFileSync('" + __dirname + '/../tmp/' + setup.appName + "-data/objects.json');}catch(err){createState('error', err.toString());}",
+                'enabled':      true,
+                'engine':       'system.adapter.javascript.0'
             },
-            "type":             "script",
-            "_id":              "script.js.open_objects",
-            "native": {}
+            'type':             'script',
+            '_id':              'script.js.open_objects',
+            'native': {}
         };
 
         const onStateChanged = function (id, state) {
@@ -442,17 +442,17 @@ describe('Test JS', function() {
     it('Test JS: write objects.json file must not work', function (done) {
         this.timeout(2000);
         // add script
-        var script = {
-            "common": {
-                "name":         "open objects",
-                "engineType":   "Javascript/js",
-                "source":       "var fs=require('fs'); try{fs.writeFileSync('" + __dirname + "/../tmp/" + setup.appName + "-data/objects.json', '');}catch(err){createState('error1', err.toString());}",
-                "enabled":      true,
-                "engine":       "system.adapter.javascript.0"
+        const script = {
+            'common': {
+                'name':         'open objects',
+                'engineType':   'Javascript/js',
+                'source':       "var fs=require('fs'); try{fs.writeFileSync('" + __dirname + '/../tmp/' + setup.appName + "-data/objects.json', '');}catch(err){createState('error1', err.toString());}",
+                'enabled':      true,
+                'engine':       'system.adapter.javascript.0'
             },
-            "type":             "script",
-            "_id":              "script.js.open_objects",
-            "native": {}
+            'type':             'script',
+            '_id':              'script.js.open_objects',
+            'native': {}
         };
         const onStateChanged = function (id, state) {
             if (id === 'javascript.0.error1' && state.val === 'Error: Permission denied') {
@@ -468,23 +468,23 @@ describe('Test JS', function() {
 
     it('Test JS: write objects.json not in data directory must work', function (done) {
         this.timeout(2000);
-        var time = new Date().toString();
-        var fs = require('fs');
+        const time = new Date().toString();
+        const fs = require('fs');
 
-        if (fs.existsSync(__dirname + "/../tmp/objects.json")) fs.unlinkSync(__dirname + "/../tmp/objects.json");
+        if (fs.existsSync(__dirname + '/../tmp/objects.json')) fs.unlinkSync(__dirname + '/../tmp/objects.json');
 
         // add script
-        var script = {
-            "common": {
-                "name":         "open objects",
-                "engineType":   "Javascript/js",
-                "source":       "var fs=require('fs'); try{fs.writeFileSync('" + __dirname.replace(/\\/g, "/") + "/../tmp/objects.json', '" + time + "');}catch(err){createState('error3', err.toString());}",
-                "enabled":      true,
-                "engine":       "system.adapter.javascript.0"
+        const script = {
+            'common': {
+                'name':         'open objects',
+                'engineType':   'Javascript/js',
+                'source':       "var fs=require('fs'); try{fs.writeFileSync('" + __dirname.replace(/\\/g, '/') + "/../tmp/objects.json', '" + time + "');}catch(err){createState('error3', err.toString());}",
+                'enabled':      true,
+                'engine':       'system.adapter.javascript.0'
             },
-            "type":             "script",
-            "_id":              "script.js.open_objects",
-            "native": {}
+            'type':             'script',
+            '_id':              'script.js.open_objects',
+            'native': {}
         };
 
         objects.setObject(script._id, script, function (err) {
@@ -492,13 +492,13 @@ describe('Test JS', function() {
             setTimeout(function () {
                 if (!fs.existsSync(__dirname + '/../tmp/objects.json')) {
                     setTimeout(function () {
-                        expect(fs.readFileSync(__dirname + "/../tmp/objects.json").toString()).to.be.equal(time);
-                        fs.unlinkSync(__dirname + "/../tmp/objects.json");
+                        expect(fs.readFileSync(__dirname + '/../tmp/objects.json').toString()).to.be.equal(time);
+                        fs.unlinkSync(__dirname + '/../tmp/objects.json');
                         done();
                     }, 500);
                 } else {
-                    expect(fs.readFileSync(__dirname + "/../tmp/objects.json").toString()).to.be.equal(time);
-                    fs.unlinkSync(__dirname + "/../tmp/objects.json");
+                    expect(fs.readFileSync(__dirname + '/../tmp/objects.json').toString()).to.be.equal(time);
+                    fs.unlinkSync(__dirname + '/../tmp/objects.json');
                     done();
                 }
             }, 500);
@@ -507,55 +507,55 @@ describe('Test JS', function() {
 
     it('Test JS: test getAstroDate', function (done) {
         this.timeout(6000);
-        var types = [
-            "sunrise",
-            "sunriseEnd",
-            "goldenHourEnd",
-            "solarNoon",
-            "goldenHour",
-            "sunsetStart",
-            "sunset",
-            "dusk",
-            "nauticalDusk",
-            "night",
-            "nightEnd",
-            "nauticalDawn",
-            "dawn",
-            "nadir"
+        const types = [
+            'sunrise',
+            'sunriseEnd',
+            'goldenHourEnd',
+            'solarNoon',
+            'goldenHour',
+            'sunsetStart',
+            'sunset',
+            'dusk',
+            'nauticalDusk',
+            'night',
+            'nightEnd',
+            'nauticalDawn',
+            'dawn',
+            'nadir'
         ];
         // add script
-        var script = {
-            "common": {
-                "name":         "getAstroDate",
-                "engineType":   "Javascript/js",
-                "source":       "",
-                "enabled":      true,
-                "engine":       "system.adapter.javascript.0"
+        const script = {
+            'common': {
+                'name':         'getAstroDate',
+                'engineType':   'Javascript/js',
+                'source':       '',
+                'enabled':      true,
+                'engine':       'system.adapter.javascript.0'
             },
-            "type":             "script",
-            "_id":              "script.js.getAstroDate",
-            "native": {}
+            'type':             'script',
+            '_id':              'script.js.getAstroDate',
+            'native': {}
         };
-        for (var t = 0; t < types.length; t++) {
-            script.common.source += "createState('" + types[t] + "', getAstroDate('" + types[t] + "') ? getAstroDate('" + types[t] + "').toString() : '');"
+        for (let t = 0; t < types.length; t++) {
+            script.common.source += "createState('" + types[t] + "', getAstroDate('" + types[t] + "') ? getAstroDate('" + types[t] + "').toString() : '');";
         }
 
-        var typesChanged = {};
+        const typesChanged = {};
         const onStateChanged = function (id, state) {
             if (types.indexOf(id.substring('javascript.0.'.length)) !== -1) {
                 typesChanged[id] = true;
-                console.log('State change '+ id + ' / ' + Object.keys(typesChanged).length + '-' + types.length + '  = ' + JSON.stringify(state))
+                console.log('State change '+ id + ' / ' + Object.keys(typesChanged).length + '-' + types.length + '  = ' + JSON.stringify(state));
                 if (Object.keys(typesChanged).length === types.length) {
                     removeStateChangedHandler(onStateChanged);
 
-                    var count = types.length;
-                    for (var t = 0; t < types.length; t++) {
+                    let count = types.length;
+                    for (let t = 0; t < types.length; t++) {
                         states.getState('javascript.0.' + types[t], function (err, state) {
                             expect(err).to.be.not.ok;
                             expect(state).to.be.ok;
                             expect(state.val).to.be.ok;
                             if (state) console.log(types[types.length - count] + ': ' + state.val);
-                              else console.log(types[types.length - count] + ' ERROR: ' + state);
+                            else console.log(types[types.length - count] + ' ERROR: ' + state);
                             if (!--count) done();
                         });
                     }
@@ -572,20 +572,20 @@ describe('Test JS', function() {
     it('Test JS: test setStateDelayed simple', function (done) {
         this.timeout(5000);
         // add script
-        var script = {
-            "common": {
-                "name":         "setStateDelayed",
-                "engineType":   "Javascript/js",
-                "source":       "createState('delayed', 4, function () {setStateDelayed('delayed', 5, 1000);});",
-                "enabled":      true,
-                "engine":       "system.adapter.javascript.0"
+        const script = {
+            'common': {
+                'name':         'setStateDelayed',
+                'engineType':   'Javascript/js',
+                'source':       "createState('delayed', 4, function () {setStateDelayed('delayed', 5, 1000);});",
+                'enabled':      true,
+                'engine':       'system.adapter.javascript.0'
             },
-            "type":             "script",
-            "_id":              "script.js.setStateDelayed",
-            "native": {}
+            'type':             'script',
+            '_id':              'script.js.setStateDelayed',
+            'native': {}
         };
 
-        var start = 0;
+        let start = 0;
         const onStateChanged = function (id, state){
             if (id !== 'javascript.0.delayed') return;
             if (state.val === 4) {
@@ -604,20 +604,20 @@ describe('Test JS', function() {
     it('Test JS: test setStateDelayed nested', function (done) {
         this.timeout(5000);
         // add script
-        var script = {
-            "common": {
-                "name":         "setStateDelayed",
-                "engineType":   "Javascript/js",
-                "source":       "setStateDelayed('delayed', 6, 500); setStateDelayed('delayed', 7, 1500, false);",
-                "enabled":      true,
-                "engine":       "system.adapter.javascript.0"
+        const script = {
+            'common': {
+                'name':         'setStateDelayed',
+                'engineType':   'Javascript/js',
+                'source':       "setStateDelayed('delayed', 6, 500); setStateDelayed('delayed', 7, 1500, false);",
+                'enabled':      true,
+                'engine':       'system.adapter.javascript.0'
             },
-            "type":             "script",
-            "_id":              "script.js.setStateDelayed",
-            "native": {}
+            'type':             'script',
+            '_id':              'script.js.setStateDelayed',
+            'native': {}
         };
 
-        var start = 0;
+        let start = 0;
         const onStateChanged = function (id, state){
             if (id !== 'javascript.0.delayed') return;
             if (state.val === 6) {
@@ -636,17 +636,17 @@ describe('Test JS', function() {
     it('Test JS: test setStateDelayed overwritten', function (done) {
         this.timeout(5000);
         // add script
-        var script = {
-            "common": {
-                "name":         "setStateDelayed",
-                "engineType":   "Javascript/js",
-                "source":       "setStateDelayed('delayed', 8, 500); setStateDelayed('delayed', 9, 1500);",
-                "enabled":      true,
-                "engine":       "system.adapter.javascript.0"
+        const script = {
+            'common': {
+                'name':         'setStateDelayed',
+                'engineType':   'Javascript/js',
+                'source':       "setStateDelayed('delayed', 8, 500); setStateDelayed('delayed', 9, 1500);",
+                'enabled':      true,
+                'engine':       'system.adapter.javascript.0'
             },
-            "type":             "script",
-            "_id":              "script.js.setStateDelayed",
-            "native": {}
+            'type':             'script',
+            '_id':              'script.js.setStateDelayed',
+            'native': {}
         };
 
         objects.setObject(script._id, script, function (err) {
@@ -673,17 +673,17 @@ describe('Test JS', function() {
     it('Test JS: test setStateDelayed canceled', function (done) {
         this.timeout(5000);
         // add script
-        var script = {
-            "common": {
-                "name":         "setStateDelayed",
-                "engineType":   "Javascript/js",
-                "source":       "setStateDelayed('delayed', 10, 500); clearStateDelayed('delayed');",
-                "enabled":      true,
-                "engine":       "system.adapter.javascript.0"
+        const script = {
+            'common': {
+                'name':         'setStateDelayed',
+                'engineType':   'Javascript/js',
+                'source':       "setStateDelayed('delayed', 10, 500); clearStateDelayed('delayed');",
+                'enabled':      true,
+                'engine':       'system.adapter.javascript.0'
             },
-            "type":             "script",
-            "_id":              "script.js.setStateDelayed",
-            "native": {}
+            'type':             'script',
+            '_id':              'script.js.setStateDelayed',
+            'native': {}
         };
 
         objects.setObject(script._id, script, function (err) {
@@ -701,88 +701,88 @@ describe('Test JS', function() {
         });
     });
 
-	it('Test JS: test getStateDelayed single', function (done) {
+    it('Test JS: test getStateDelayed single', function (done) {
         this.timeout(5000);
         // add script
-        var script = {
-            "common": {
-                "name":         "setStateDelayed",
-                "engineType":   "Javascript/js",
-                "source":       "createState('delayedResult', '', function () {setStateDelayed('delayed', 10, 1500); setState('delayedResult', JSON.stringify(getStateDelayed('delayed')));});",
-                "enabled":      true,
-                "engine":       "system.adapter.javascript.0"
+        const script = {
+            'common': {
+                'name':         'setStateDelayed',
+                'engineType':   'Javascript/js',
+                'source':       "createState('delayedResult', '', function () {setStateDelayed('delayed', 10, 1500); setState('delayedResult', JSON.stringify(getStateDelayed('delayed')));});",
+                'enabled':      true,
+                'engine':       'system.adapter.javascript.0'
             },
-            "type":             "script",
-            "_id":              "script.js.setStateDelayed",
-            "native": {}
+            'type':             'script',
+            '_id':              'script.js.setStateDelayed',
+            'native': {}
         };
 
         objects.setObject(script._id, script, function (err) {
             expect(err).to.be.not.ok;
 
-			setTimeout(function () {
-				states.getState('javascript.0.delayedResult', function (err, delayedResult) {
-					expect(err).to.be.not.ok;
-					console.log('delayedResult: ' + delayedResult.val);
-					var result = JSON.parse(delayedResult.val);
-					expect(result[0]).to.be.ok;
-					expect(result[0].timerId).to.be.ok;
-					expect(result[0].left).to.be.ok;
-					expect(result[0].delay).to.be.equal(1500);
-					done();
-				});
-			}, 500);
+            setTimeout(function () {
+                states.getState('javascript.0.delayedResult', function (err, delayedResult) {
+                    expect(err).to.be.not.ok;
+                    console.log('delayedResult: ' + delayedResult.val);
+                    const result = JSON.parse(delayedResult.val);
+                    expect(result[0]).to.be.ok;
+                    expect(result[0].timerId).to.be.ok;
+                    expect(result[0].left).to.be.ok;
+                    expect(result[0].delay).to.be.equal(1500);
+                    done();
+                });
+            }, 500);
         });
     });
 
-	it('Test JS: test getStateDelayed all', function (done) {
+    it('Test JS: test getStateDelayed all', function (done) {
         this.timeout(5000);
         // add script
-        var script = {
-            "common": {
-                "name":         "setStateDelayed",
-                "engineType":   "Javascript/js",
-                "source":       "createState('delayedResult', '', function () {setStateDelayed('delayed', 11, 2500); setState('delayedResult', JSON.stringify(getStateDelayed()));});",
-                "enabled":      true,
-                "engine":       "system.adapter.javascript.0"
+        const script = {
+            'common': {
+                'name':         'setStateDelayed',
+                'engineType':   'Javascript/js',
+                'source':       "createState('delayedResult', '', function () {setStateDelayed('delayed', 11, 2500); setState('delayedResult', JSON.stringify(getStateDelayed()));});",
+                'enabled':      true,
+                'engine':       'system.adapter.javascript.0'
             },
-            "type":             "script",
-            "_id":              "script.js.setStateDelayed",
-            "native": {}
+            'type':             'script',
+            '_id':              'script.js.setStateDelayed',
+            'native': {}
         };
 
         objects.setObject(script._id, script, function (err) {
             expect(err).to.be.not.ok;
 
-			setTimeout(function () {
-				states.getState('javascript.0.delayedResult', function (err, delayedResult) {
-					console.log('delayedResult!: ' + delayedResult.val);
-					expect(err).to.be.not.ok;
-					var result = JSON.parse(delayedResult.val);
-					expect(result['javascript.0.delayed'][0]).to.be.ok;
-					expect(result['javascript.0.delayed'][0].timerId).to.be.ok;
-					expect(result['javascript.0.delayed'][0].left).to.be.ok;
-					expect(result['javascript.0.delayed'][0].delay).to.be.equal(2500);
-					done();
-				});
-			}, 500);
+            setTimeout(function () {
+                states.getState('javascript.0.delayedResult', function (err, delayedResult) {
+                    console.log('delayedResult!: ' + delayedResult.val);
+                    expect(err).to.be.not.ok;
+                    const result = JSON.parse(delayedResult.val);
+                    expect(result['javascript.0.delayed'][0]).to.be.ok;
+                    expect(result['javascript.0.delayed'][0].timerId).to.be.ok;
+                    expect(result['javascript.0.delayed'][0].left).to.be.ok;
+                    expect(result['javascript.0.delayed'][0].delay).to.be.equal(2500);
+                    done();
+                });
+            }, 500);
         });
     });
 
     it('Test JS: test stopScript', function (done) {
         this.timeout(5000);
         // add script
-        var script = {
-            "common": {
-                "name":         "stopScript",
-                "engineType":   "Javascript/js",
-                "source":       "stopScript('stopScript');",
-                "enabled":      true,
-                "engine":       "system.adapter.javascript.0"
+        const script = {
+            'common': {
+                'name':         'stopScript',
+                'engineType':   'Javascript/js',
+                'source':       "stopScript('stopScript');",
+                'enabled':      true,
+                'engine':       'system.adapter.javascript.0'
             },
-            "type":             "script",
-            "_id":              "script.js.stopScript",
-            "native": {}
+            'type':             'script',
+            '_id':              'script.js.stopScript',
+            'native': {}
         };
 
         objects.setObject(script._id, script, function (err) {
@@ -800,29 +800,29 @@ describe('Test JS', function() {
     it('Test JS: test startScript', function (done) {
         this.timeout(5000);
         // add script
-        var script = {
-            "common": {
-                "name":         "startScript",
-                "engineType":   "Javascript/js",
-                "source":       "startScript('stopScript');",
-                "enabled":      true,
-                "engine":       "system.adapter.javascript.0"
+        const script = {
+            'common': {
+                'name':         'startScript',
+                'engineType':   'Javascript/js',
+                'source':       "startScript('stopScript');",
+                'enabled':      true,
+                'engine':       'system.adapter.javascript.0'
             },
-            "type":             "script",
-            "_id":              "script.js.startScript",
-            "native": {}
+            'type':             'script',
+            '_id':              'script.js.startScript',
+            'native': {}
         };
-        var stopScript = {
-            "common": {
-                "name":         "stopScript",
-                "engineType":   "Javascript/js",
-                "source":       "console.log('aaa');",
-                "enabled":      false,
-                "engine":       "system.adapter.javascript.0"
+        const stopScript = {
+            'common': {
+                'name':         'stopScript',
+                'engineType':   'Javascript/js',
+                'source':       "console.log('aaa');",
+                'enabled':      false,
+                'engine':       'system.adapter.javascript.0'
             },
-            "type":             "script",
-            "_id":              "script.js.stopScript",
-            "native": {}
+            'type':             'script',
+            '_id':              'script.js.stopScript',
+            'native': {}
         };
 
         objects.setObject(stopScript._id, stopScript, function (err) {
@@ -846,17 +846,17 @@ describe('Test JS', function() {
     it('Test JS: test global scripts New', function (done) {
         this.timeout(5000);
         // add script
-        var script = {
-            "common": {
-                "name":         "new script non global",
-                "engineType":   "Javascript/js",
-                "source":       "setTestState(16);",
-                "enabled":      true,
-                "engine":       "system.adapter.javascript.0"
+        const script = {
+            'common': {
+                'name':         'new script non global',
+                'engineType':   'Javascript/js',
+                'source':       'setTestState(16);',
+                'enabled':      true,
+                'engine':       'system.adapter.javascript.0'
             },
-            "type":             "script",
-            "_id":              "script.js.TestGlobalNew.Script",
-            "native": {}
+            'type':             'script',
+            '_id':              'script.js.TestGlobalNew.Script',
+            'native': {}
         };
         objects.setObject(script._id, script, function (err) {
             expect(err).to.be.not.ok;
@@ -876,17 +876,17 @@ describe('Test JS', function() {
     it('Test JS: test global scripts Old', function (done) {
         this.timeout(5000);
         // add script
-         var script = {
-            "common": {
-                "name":         "Old script non global",
-                "engineType":   "Javascript/js",
-                "source":       "setTestStateOld(17);",
-                "enabled":      true,
-                "engine":       "system.adapter.javascript.0"
+        const script = {
+            'common': {
+                'name':         'Old script non global',
+                'engineType':   'Javascript/js',
+                'source':       'setTestStateOld(17);',
+                'enabled':      true,
+                'engine':       'system.adapter.javascript.0'
             },
-            "type":             "script",
-            "_id":              "script.js.TestGlobalOld.Script",
-            "native": {}
+            'type':             'script',
+            '_id':              'script.js.TestGlobalOld.Script',
+            'native': {}
         };
         objects.setObject(script._id, script, function (err) {
             expect(err).to.be.not.ok;
@@ -906,17 +906,17 @@ describe('Test JS', function() {
     it('Test JS: test ON default', function (done) {
         this.timeout(5000);
         // add script
-        var script = {
-            "common": {
-                "name":         "test ON default",
-                "engineType":   "Javascript/js",
-                "source":       "createState('testResponse', false);createState('testVar', 0, function () {on('testVar', function (obj) {setState('testResponse', obj.state.val, true);});});",
-                "enabled":      true,
-                "engine":       "system.adapter.javascript.0"
+        const script = {
+            'common': {
+                'name':         'test ON default',
+                'engineType':   'Javascript/js',
+                'source':       "createState('testResponse', false);createState('testVar', 0, function () {on('testVar', function (obj) {setState('testResponse', obj.state.val, true);});});",
+                'enabled':      true,
+                'engine':       'system.adapter.javascript.0'
             },
-            "type":             "script",
-            "_id":              "script.js.test_ON_default",
-            "native": {}
+            'type':             'script',
+            '_id':              'script.js.test_ON_default',
+            'native': {}
         };
 
         const onStateChanged = function (id, state) {
@@ -940,17 +940,17 @@ describe('Test JS', function() {
     it('Test JS: test ON any', function (done) {
         this.timeout(5000);
         // add script
-        var script = {
-            "common": {
-                "name":         "test ON any",
-                "engineType":   "Javascript/js",
-                "source":       "createState('testResponse1', false);createState('testVar1', 1, function () {on({id:'testVar1', change:'any'}, function (obj) {setState('testResponse1', obj.state.val, true);});});",
-                "enabled":      true,
-                "engine":       "system.adapter.javascript.0"
+        const script = {
+            'common': {
+                'name':         'test ON any',
+                'engineType':   'Javascript/js',
+                'source':       "createState('testResponse1', false);createState('testVar1', 1, function () {on({id:'testVar1', change:'any'}, function (obj) {setState('testResponse1', obj.state.val, true);});});",
+                'enabled':      true,
+                'engine':       'system.adapter.javascript.0'
             },
-            "type":             "script",
-            "_id":              "script.js.test_ON_any",
-            "native": {}
+            'type':             'script',
+            '_id':              'script.js.test_ON_any',
+            'native': {}
         };
 
         const onStateChanged = function (id, state) {
@@ -978,11 +978,11 @@ describe('Test JS', function() {
         ////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
         function scriptFunction (param) {
-            var results = '';
-            var TEST_VAR = 'javascript.0.device.channel.testVar';
-            var TEST_RESULTS = 'javascript.0.testResults';
+            let results = '';
+            const TEST_VAR = 'javascript.0.device.channel.testVar';
+            const TEST_RESULTS = 'javascript.0.testResults';
 
-            var recs = [
+            const recs = [
                 // request Options                                 // on options or iD                       // states to set
                 [ { no:  1, cnt: 2, val: true },                   { id: /\.testVar$/, val: true },                            [ true, false, { val: true, ack: true } ] ],
                 [ { no:  2, cnt: 2, val: true },                   { id: 0, val: true },                                       [ true, false, { val: true, ack: true } ] ],
@@ -1066,7 +1066,7 @@ describe('Test JS', function() {
             function handler(result, req, obj) {
                 //log ('handler: ' + JSON.stringify (req));
                 if (typeof result.val === 'object') {
-                    for (var n in result.val) {
+                    for (const n in result.val) {
                         addResult ('obj.state.' + n + '=' + obj.state[n] + ' val.' + n + '=' + result.val[n]);
                         result.nok = result.nok || (result.val[n] !== obj.state[n]);
                     }
@@ -1087,9 +1087,9 @@ describe('Test JS', function() {
                     req.nok = false;
                     req.callCount = 0;
                     if (req.cnt === undefined) req.cnt = 1;
-                    var sub = on (obj, handler.bind(1, req, obj));
+                    const sub = on (obj, handler.bind(1, req, obj));
                     if (!ar) return doIt();
-                    var no = 0;
+                    let no = 0;
                     (function doIt() {
                         if (no >= ar.length) {
                             setTimeout(function () {
@@ -1099,21 +1099,21 @@ describe('Test JS', function() {
                             }, req.tio);
                             return;
                         }
-                        var o = ar[no++];
+                        let o = ar[no++];
                         if (typeof o !== 'object') {
                             o = { val: o };
                         }
-                        setState(TEST_VAR, o.val, o.ack, doIt)
+                        setState(TEST_VAR, o.val, o.ack, doIt);
                     })();
                 });
             }
 
             function runTests (id) {
                 createState(id, '', true, { name: 'Hello' }, function (err, obj) {
-                    var cnt = 0;
+                    let cnt = 0;
                     (function doIt() {
                         if (cnt >= recs.length) return;
-                        var rec = recs[cnt++];
+                        const rec = recs[cnt++];
                         createTest(rec[0], rec[1], rec[2], doIt);
                     })();
                 });
@@ -1123,44 +1123,44 @@ describe('Test JS', function() {
 
         ////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-        var script = {
-            "common": {
-                "name":         "test ON any",
-                "engineType":   "Javascript/js",
-                "source":       scriptFunction.toString() + '\r\nscriptFunction();\r\n',
-                "enabled":      true,
-                "engine":       "system.adapter.javascript.0"
+        const script = {
+            'common': {
+                'name':         'test ON any',
+                'engineType':   'Javascript/js',
+                'source':       scriptFunction.toString() + '\r\nscriptFunction();\r\n',
+                'enabled':      true,
+                'engine':       'system.adapter.javascript.0'
             },
-            "type":             "script",
-            "_id":              "script.js.test_ON",
-            "native": {}
+            'type':             'script',
+            '_id':              'script.js.test_ON',
+            'native': {}
         };
 
 
-        var recs = scriptFunction('recs');
-        var TEST_VAR = scriptFunction('TEST_VAR');
+        const recs = scriptFunction('recs');
+        const TEST_VAR = scriptFunction('TEST_VAR');
         this.timeout(5000 + 500*recs.length);
 
         function createObjects(callback) {
-            var channel = TEST_VAR.replace(/\.[^.]+$/, '');
-            var device = channel.replace(/\.[^.]+$/, '');
+            const channel = TEST_VAR.replace(/\.[^.]+$/, '');
+            const device = channel.replace(/\.[^.]+$/, '');
             objects.setObject(device, { common: { name: 'Device', type: 'device'}}, function (err, obj) {
-                expect(err).to.be.not.ok
-                objects.setObject(channel, { common: { name: 'Channel', type: 'channel'}}, callback)
-            })
+                expect(err).to.be.not.ok;
+                objects.setObject(channel, { common: { name: 'Channel', type: 'channel'}}, callback);
+            });
         }
 
         createObjects(function (err, _obj) {
-            expect(err).to.be.not.ok
+            expect(err).to.be.not.ok;
             // objects.getObject('system.adapter.javascript.0', function(err, obj) {
             //     obj.native.enableSetObject = true;
             //     objects.setObject('system.adapter.javascript.0', function(err, obj) {
-            var cnt = 0;
+            let cnt = 0;
 
             const onStateChanged = function (id, state) {
                 if (id === 'javascript.0.testResults' && state.val) {
                     cnt += 1;
-                    var ar = /^(OK;no=[\d]+)/.exec(state.val) || ['', state.val];
+                    const ar = /^(OK;no=[\d]+)/.exec(state.val) || ['', state.val];
                     expect(ar).to.be.ok;
                     expect(ar[1]).to.be.equal('OK;no=' + cnt);
 
@@ -1175,28 +1175,28 @@ describe('Test JS', function() {
             objects.setObject(script._id, script, function (err) {
                 expect(err).to.be.not.ok;
             });
-        })
+        });
 
 
     });
 
     it('Test JS: test schedule for seconds', function (done) {
         this.timeout(4000);
-        var d = new Date();
+        const d = new Date();
 
         console.log('Must wait 2 seconds[' + ((d.getSeconds() + 2) % 60) + ' * * * * *]' + d.toISOString());
         // add script
-        var script = {
-            "common": {
-                "name":         "test ON any",
-                "engineType":   "Javascript/js",
-                "source":       "createState('testScheduleResponse', false);schedule('" + ((d.getSeconds() + 2) % 60) + " * * * * *', function (obj) {setState('testScheduleResponse', true, true);});",
-                "enabled":      true,
-                "engine":       "system.adapter.javascript.0"
+        const script = {
+            'common': {
+                'name':         'test ON any',
+                'engineType':   'Javascript/js',
+                'source':       "createState('testScheduleResponse', false);schedule('" + ((d.getSeconds() + 2) % 60) + " * * * * *', function (obj) {setState('testScheduleResponse', true, true);});",
+                'enabled':      true,
+                'engine':       'system.adapter.javascript.0'
             },
-            "type":             "script",
-            "_id":              "script.js.test_ON_any",
-            "native": {}
+            'type':             'script',
+            '_id':              'script.js.test_ON_any',
+            'native': {}
         };
 
         const onStateChanged = function (id, state) {
@@ -1213,22 +1213,22 @@ describe('Test JS', function() {
     });
 
     it('Test JS: test schedule for minutes', function (done) {
-        var d = new Date();
+        const d = new Date();
         console.log('Must wait ' + (60 - d.getSeconds()) + ' seconds[' + ((d.getMinutes() + 1) % 60) + ' * * * *] ' + d.toISOString());
         this.timeout((64 - d.getSeconds()) * 1000);
 
         // add script
-        var script = {
-            "common": {
-                "name":         "test ON any",
-                "engineType":   "Javascript/js",
-                "source":       "createState('testScheduleResponse1', false);schedule('" + ((d.getMinutes() + 1) % 60) + " * * * *', function (obj) {setState('testScheduleResponse1', true, true);});",
-                "enabled":      true,
-                "engine":       "system.adapter.javascript.0"
+        const script = {
+            'common': {
+                'name':         'test ON any',
+                'engineType':   'Javascript/js',
+                'source':       "createState('testScheduleResponse1', false);schedule('" + ((d.getMinutes() + 1) % 60) + " * * * *', function (obj) {setState('testScheduleResponse1', true, true);});",
+                'enabled':      true,
+                'engine':       'system.adapter.javascript.0'
             },
-            "type":             "script",
-            "_id":              "script.js.test_ON_any",
-            "native": {}
+            'type':             'script',
+            '_id':              'script.js.test_ON_any',
+            'native': {}
         };
 
         const onStateChanged = function (id, state) {
@@ -1247,17 +1247,17 @@ describe('Test JS', function() {
     it('Test JS: test write file to "javascript"', function (done) {
         this.timeout(5000);
         // add script
-        var script = {
-            "common": {
-                "name":         "test ON any",
-                "engineType":   "Javascript/js",
-                "source":       "createState('testScheduleResponse2', false, function () {writeFile('/test.txt', 'test', function () {setState('testScheduleResponse2', true, true);});});",
-                "enabled":      true,
-                "engine":       "system.adapter.javascript.0"
+        const script = {
+            'common': {
+                'name':         'test ON any',
+                'engineType':   'Javascript/js',
+                'source':       "createState('testScheduleResponse2', false, function () {writeFile('/test.txt', 'test', function () {setState('testScheduleResponse2', true, true);});});",
+                'enabled':      true,
+                'engine':       'system.adapter.javascript.0'
             },
-            "type":             "script",
-            "_id":              "script.js.test_write",
-            "native": {}
+            'type':             'script',
+            '_id':              'script.js.test_write',
+            'native': {}
         };
 
         const onStateChanged = function (id, state) {
@@ -1276,17 +1276,17 @@ describe('Test JS', function() {
     it('Test JS: test read file from "javascript"', function (done) {
         this.timeout(5000);
         // add script
-        var script = {
-            "common": {
-                "name":         "test ON any",
-                "engineType":   "Javascript/js",
-                "source":       "readFile('/test.txt', function (err, data) {setState('testScheduleResponse2', data, true);});",
-                "enabled":      true,
-                "engine":       "system.adapter.javascript.0"
+        const script = {
+            'common': {
+                'name':         'test ON any',
+                'engineType':   'Javascript/js',
+                'source':       "readFile('/test.txt', function (err, data) {setState('testScheduleResponse2', data, true);});",
+                'enabled':      true,
+                'engine':       'system.adapter.javascript.0'
             },
-            "type":             "script",
-            "_id":              "script.js.test_read",
-            "native": {}
+            'type':             'script',
+            '_id':              'script.js.test_read',
+            'native': {}
         };
 
         const onStateChanged = function (id, state) {
@@ -1305,17 +1305,17 @@ describe('Test JS', function() {
     it('Test JS: test write file  to "vis.0"', function (done) {
         this.timeout(5000);
         // add script
-        var script = {
-            "common": {
-                "name":         "test ON any",
-                "engineType":   "Javascript/js",
-                "source":       "createState('testScheduleResponse2', false, function () {writeFile('vis.0', '/test1.txt', 'test', function () {setState('testScheduleResponse2', true, true);});});",
-                "enabled":      true,
-                "engine":       "system.adapter.javascript.0"
+        const script = {
+            'common': {
+                'name':         'test ON any',
+                'engineType':   'Javascript/js',
+                'source':       "createState('testScheduleResponse2', false, function () {writeFile('vis.0', '/test1.txt', 'test', function () {setState('testScheduleResponse2', true, true);});});",
+                'enabled':      true,
+                'engine':       'system.adapter.javascript.0'
             },
-            "type":             "script",
-            "_id":              "script.js.test_write1",
-            "native": {}
+            'type':             'script',
+            '_id':              'script.js.test_write1',
+            'native': {}
         };
 
         const onStateChanged = function (id, state) {
@@ -1334,17 +1334,17 @@ describe('Test JS', function() {
     it('Test JS: test read file from "vis.0"', function (done) {
         this.timeout(5000);
         // add script
-        var script = {
-            "common": {
-                "name":         "test ON any",
-                "engineType":   "Javascript/js",
-                "source":       "readFile('vis.0', '/test1.txt', function (err, data) {setState('testScheduleResponse2', data, true);});",
-                "enabled":      true,
-                "engine":       "system.adapter.javascript.0"
+        const script = {
+            'common': {
+                'name':         'test ON any',
+                'engineType':   'Javascript/js',
+                'source':       "readFile('vis.0', '/test1.txt', function (err, data) {setState('testScheduleResponse2', data, true);});",
+                'enabled':      true,
+                'engine':       'system.adapter.javascript.0'
             },
-            "type":             "script",
-            "_id":              "script.js.test_read1",
-            "native": {}
+            'type':             'script',
+            '_id':              'script.js.test_read1',
+            'native': {}
         };
 
         const onStateChanged = function (id, state) {


### PR DESCRIPTION
This PR fixes a bunch of issues found by ESLint and lgtm.com :policeman: 
See below/in the files for details

@GermanBluefox 
I did not change a whole bunch of direct assignments to React state, because I'm not sure if that would break the behavior. However this should never be done. From the [React docs](https://reactjs.org/docs/react-component.html):

> You should not call setState() in the constructor(). Instead, if your component needs to use local state, assign the initial state to this.state directly in the constructor:
> Constructor is the only place where you should assign this.state directly. In all other methods, you **need to use this.setState()** instead.