### PR TITLE
Improve the warning message when assigning a variable of wrong type to a state

### DIFF
--- a/lib/sandbox.js
+++ b/lib/sandbox.js
@@ -210,13 +210,15 @@ function sandBox(script, name, verbose, debug, context) {
     }
 
     /**
-     * Tests if the given value has the correct type as defined in common.type
-     * @param {iobJS.CommonType} commonType
+     * Returns the common.type for a given variable
      * @param {any} value
+     * @returns {iobJS.CommonType}
      */
-    function checkCommonType(commonType, value) {
-        return commonType === 'array' ? isArray(value)
-            : (commonType === 'object' ? isObject(value) : commonType === typeof value);
+    function getCommonTypeOf(value) {
+        // @ts-ignore we do not support bigint
+        return isArray(value) ? 'array'
+            : isObject(value) ? 'object'
+            : typeof value;
     }
 
     function setStateHelper(sandbox, isBinary, id, state, isAck, callback) {
@@ -254,17 +256,22 @@ function sandBox(script, name, verbose, debug, context) {
             common.type &&
             common.type !== 'mixed' &&
             common.type !== 'file'  &&
-            common.type !== 'json') {
+            common.type !== 'json'
+        ) {
+            // Find out which type the value has
+            let actualCommonType;
             if (state && isObject(state) && state.val !== undefined) {
-                if (!checkCommonType(common.type, state.val)) {
-                    context.logWithLineInfo && context.logWithLineInfo.warn('Wrong type of ' + id + ': "' + typeof state.val + '". Please fix, while deprecated and will not work in next versions.');
-                    //return;
-                }
+                actualCommonType = getCommonTypeOf(state.val);
             } else {
-                if (!checkCommonType(common.type, state)) {
-                    context.logWithLineInfo && context.logWithLineInfo.warn('Wrong type of ' + id + ': "' + typeof state + '". Please fix, while deprecated and will not work in next versions.');
-                    //return;
-                }
+                actualCommonType = getCommonTypeOf(state);
+            }
+            // If this is not the expected one, issue a warning
+            if (actualCommonType !== common.type) {
+                context.logWithLineInfo && context.logWithLineInfo.warn(
+                    `You are assigning a ${actualCommonType} to the state "${id}" which expects a ${common.type}. `
+                    + `Please fix your code to use a ${common.type} or change the state type to ${actualCommonType}. `
+                    + `This warning might become an error in future versions.`
+                );
             }
         }
         // Check min and max of value


### PR DESCRIPTION
Fixes: #362

The message is now:
> You are assigning a ${actualCommonType} to the state "${id}" which expects a ${common.type}.
> Please fix your code to use a ${common.type} or change the state type to ${actualCommonType}.
> This warning might become an error in future versions.

