### PR TITLE
Update sandbox.js

### DIFF
--- a/lib/sandbox.js
+++ b/lib/sandbox.js
@@ -1213,6 +1213,10 @@ function sandBox(script, name, verbose, debug, context) {
             }
 
             let ts = mods.suncalc.getTimes(date, adapter.config.latitude, adapter.config.longitude)[pattern];
+            let nadir = mods.suncalc.getTimes(date, adapter.config.latitude, adapter.config.longitude)['nadir'];
+            if (nadir.getDate() === date.getDate()) {
+                ts = mods.suncalc.getTimes(date.setDate(date.getDate() + 1), adapter.config.latitude, adapter.config.longitude)[pattern];
+            }
 
             if (ts === undefined || ts.getTime().toString() === 'NaN') {
                 adapter.log.error('Cannot get astro date for "' + pattern + '"');

--- a/lib/sandbox.js
+++ b/lib/sandbox.js
@@ -1214,8 +1214,11 @@ function sandBox(script, name, verbose, debug, context) {
 
             let ts = mods.suncalc.getTimes(date, adapter.config.latitude, adapter.config.longitude)[pattern];
             let nadir = mods.suncalc.getTimes(date, adapter.config.latitude, adapter.config.longitude)['nadir'];
-            if (nadir.getDate() === date.getDate()) {
+            if (nadir.getDate() === date.getDate() && nadir.getHours() < 12) {
                 ts = mods.suncalc.getTimes(date.setDate(date.getDate() + 1), adapter.config.latitude, adapter.config.longitude)[pattern];
+            }
+            if (nadir.getDate() !== date.getDate() && nadir.getHours() > 12) {
+                ts = mods.suncalc.getTimes(date.setDate(date.getDate() - 1), adapter.config.latitude, adapter.config.longitude)[pattern];
             }
 
             if (ts === undefined || ts.getTime().toString() === 'NaN') {


### PR DESCRIPTION
Korrektur: suncalc.getTimes liefert zwischen Mitternacht und "nadir" die Astrozeiten vom Vortag.