### PR TITLE
Load TypeScript declarations for 3rd party modules and provide them to the editor

### DIFF
--- a/lib/javascript.d.ts
+++ b/lib/javascript.d.ts
@@ -140,10 +140,13 @@ declare global {
 			[propName: string]: any;
 		};
 
-		interface TargetObject {
-            instance: string; // javascript instance (optional)
-            script: string;   // script name (optional)
-            message: string; // message name (required)
+		interface MessageTarget {
+			/** Javascript Instance */
+			instance?: string;
+			/** Script name */
+			script?: string;
+			/** Message name */
+			message: string;
 		}
 
 		type MessageSubscribeID = number;
@@ -508,12 +511,12 @@ declare global {
 			rule: ScheduleRule | Date | string | number;
 		}
 
-        interface LogMessage {
-            severity: LogLevel; // severity
-            ts: number; 		// timestamp as Date.now()
-            message: string; 	// message
-            from: string; 		// origin of the message
-        }
+		interface LogMessage {
+			severity: LogLevel; // severity
+			ts: number; 		// timestamp as Date.now()
+			message: string; 	// message
+			from: string; 		// origin of the message
+		}
 
 		type SchedulePattern = ScheduleRule | ScheduleRuleConditional | Date | string | number;
 
@@ -557,15 +560,16 @@ declare global {
 	function log(message: string, severity?: iobJS.LogLevel): void;
 
 	// console functions
+	// @ts-ignore We need this variable although it conflicts with the node typings
 	namespace console {
-	 	/** log message with debug level */
-	 	function debug(message: string): void;
-	 	/** log message with info level (default output level for all adapters) */
-	 	function info(message: string): void;
-	 	/** log message with warning severity */
-	 	function warn(message: string): void;
-	 	/** log message with error severity */
-	 	function error(message: string): void;
+		/** log message with debug level */
+		function debug(message: string): void;
+		/** log message with info level (default output level for all adapters) */
+		function info(message: string): void;
+		/** log message with warning severity */
+		function warn(message: string): void;
+		/** log message with error severity */
+		function error(message: string): void;
 	}
 
 	/**
@@ -892,40 +896,40 @@ declare global {
 	function getAttr(obj: string | Record<string, any>, path: string | string[]): any;
 
     /**
-     * Send message to other script.
+     * Sends a message to another script.
      * @param target Message name or target object
      * @param data Any data, that should be sent to message bus
      * @param options Actually only {timeout: X} is supported as option
      * @param callback Callback to get the result from other script
      * @return ID of the subscription. It could be used for un-subscribe.
      */
-    function messageTo(target: iobJS.TargetObject | string, data: any, options?: any, callback?: SimpleCallback<any>): iobJS.MessageSubscribeID;
+	function messageTo(target: iobJS.MessageTarget | string, data: any, options?: any, callback?: SimpleCallback<any>): iobJS.MessageSubscribeID;
 
     /**
      * Process message from other script.
      * @param message Message name
      * @param callback Callback to send the result to other script
      */
-    function onMessage(message: string, callback?: SimpleCallback<any>);
+	function onMessage(message: string, callback?: SimpleCallback<any>);
 
     /**
      * Unregister onmessage handler
      * @param id Message subscription id from onMessage or by message name
      * @return true if subscription exists and was deleted.
      */
-    function onMessageUnregister(id: iobJS.MessageSubscribeID | string): boolean;
+	function onMessageUnregister(id: iobJS.MessageSubscribeID | string): boolean;
 
     /**
      * Receives logs of specified severity level in script.
      * @param severity Severity level
      * @param callback Callback to send the result to other script
      */
-    function onLog(severity: iobJS.LogLevel, callback: SimpleCallback<iobJS.LogMessage>);
+	function onLog(severity: iobJS.LogLevel, callback: SimpleCallback<iobJS.LogMessage>);
 
     /**
      * Unsubscribe log handler.
      * @param idOrCallbackOrSeverity Message subscription id from onLog or by callback function
      * @return true if subscription exists and was deleted.
      */
-    function onLogUnregister(idOrCallbackOrSeverity: iobJS.MessageSubscribeID | SimpleCallback<iobJS.LogMessage> | iobJS.LogLevel): boolean;
+	function onLogUnregister(idOrCallbackOrSeverity: iobJS.MessageSubscribeID | SimpleCallback<iobJS.LogMessage> | iobJS.LogLevel): boolean;
 }

--- a/lib/tools.js
+++ b/lib/tools.js
@@ -1,3 +1,8 @@
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
 /**
  * Tests whether the given variable is a real object and not an Array
  * @param {any} it The variable to test
@@ -19,7 +24,46 @@ function isArray(it) {
     return Object.prototype.toString.call(it) === '[object Array]';
 }
 
+/**
+ * Finds all matches of a regular expression and returns the matched groups
+ * @param {RegExp} regex The regular expression to match against the string
+ * @param {string} string The string to test
+ */
+function matchAll(regex, string) {
+    const ret = [];
+    let match;
+    do {
+        match = regex.exec(string);
+        if (match) ret.push(match.slice(1));
+    } while (match);
+    return ret;
+}
+
+/**
+ * Enumerates all files matching a given predicate
+ * @param {string} rootDir The directory to start in
+ * @param {(filename: string) => boolean} [predicate]
+ */
+function enumFilesRecursiveSync(rootDir, predicate) {
+    const ret = [];
+    const filesAndDirs = fs.readdirSync(rootDir);
+    for (const f of filesAndDirs) {
+        const fullPath = path.join(rootDir, f);
+        if (fs.statSync(fullPath).isDirectory()) {
+            Array.prototype.push.apply(ret, enumFilesRecursiveSync(fullPath, predicate));
+        } else {
+            if (typeof predicate === 'function' && predicate(fullPath)) {
+                ret.push(fullPath);
+            }
+        }
+    }
+    return ret;
+}
+
+
 module.exports = {
     isArray,
     isObject,
+    matchAll,
+    enumFilesRecursiveSync
 };

--- a/lib/typescriptTools.js
+++ b/lib/typescriptTools.js
@@ -1,0 +1,116 @@
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const { matchAll } = require('./tools');
+
+/**
+ * Resolves all TypeScript lib files for the editor
+ * @param {string} targetLib The lib to target (e.g. es2017)
+ */
+function resolveTypescriptLibs(targetLib) {
+    const typescriptLibRoot = path.dirname(require.resolve(`typescript/lib/lib.d.ts`));
+    const ret = {};
+
+    const libReferenceRegex = /\/\/\/ <reference lib=(?:"|')([^"']+)(?:"|') \/>/g;
+    const matchAllLibs = (string) => matchAll(libReferenceRegex, string).map(groups => groups[0]);
+
+    const libQueue = [targetLib];
+    while (libQueue.length > 0) {
+        const libName = libQueue.shift();
+        const filename = `lib.${libName}.d.ts`;
+        // Read the file and remember it in the return dictionary
+        const fileContent = fs.readFileSync(path.join(typescriptLibRoot, filename), 'utf8');
+        ret[filename] = fileContent;
+        // If this file references another lib file, we need to load that too
+        // A reference looks like this: /// <reference lib="es2015.core" />
+        // Find all libs we have not loaded yet
+        matchAllLibs(fileContent)
+            .filter(lib => !(`lib.${lib}.d.ts` in ret))
+            .forEach(lib => libQueue.push(lib));
+    }
+    return ret;
+}
+
+/**
+ * Resolves the type declarations of a 3rd party package for the editor
+ * @param {string} pkg The package whose typings we're interested in
+ * @param {boolean} [wrapInDeclareModule=false] Whether the root file should be wrapped in `declare module "<pkg>" { ... }`
+ */
+function resolveTypings(pkg, wrapInDeclareModule) {
+    let packageJsonPath;
+    // First, try to resolve the package itself in case it brings its own typings
+    try {
+        packageJsonPath = require.resolve(`${pkg}/package.json`);
+    } catch (e) {
+        // If that didn't work, try again with the @types version of the package
+        try {
+            packageJsonPath = require.resolve(`@types/${pkg}/package.json`);
+        } catch (e) {
+            // TODO: download @types/<packagename>
+            return {};
+        }
+    }
+    const packageJson = require(packageJsonPath);
+
+    /** @type {string | undefined} */
+    let rootTypings = typeof packageJson.types === 'string' ? packageJson.types
+        : typeof packageJson.typings === 'string' ? packageJson.typings
+            : undefined;
+    if (!rootTypings) return {};
+
+    const packageRoot = path.dirname(packageJsonPath);
+
+    const ret = {};
+
+    // We need to look at `import ... from 'modulename'` and `/// <reference path='...' />`
+    const importDtsRegex = /import .+ from (?:"|')(\.\/[^"']+)(?:"|')/g;
+    const pathReferenceRegex = /\/\/\/ <reference path=(?:"|')([^"']+)(?:"|') \/>/g;
+    const matchAllImports = (string) => [
+        ...matchAll(importDtsRegex, string),
+        ...matchAll(pathReferenceRegex, string)
+    ].map(groups => groups[0]);
+
+    // some @types packages specify `index` as their typings file instead of `index.d.ts`
+    if (!rootTypings.endsWith('.d.ts')) rootTypings += '.d.ts';
+    rootTypings = path.join(packageRoot, rootTypings);
+
+    const definitionQueue = [rootTypings];
+    while (definitionQueue.length > 0) {
+        const filename = definitionQueue.shift();
+        const dirname = path.dirname(filename);
+        // Read the file and remember it in the return dictionary
+        const fileContent = fs.readFileSync(filename, 'utf8');
+        // We need to store the filename relative to the base dir
+        const relativePath = `@types/${pkg}/${path.relative(packageRoot, filename)}`.replace(/\\/g, '/');
+        // If necessary, wrap the root typings (only those!)
+        ret[relativePath] = wrapInDeclareModule && filename === rootTypings
+            ? `declare module "${pkg}" { ${fileContent} }`
+            : fileContent;
+        // If this file references another .d.ts file, we need to load that too
+        matchAllImports(fileContent)
+            // resolve the file relative to the current directory
+            .map(file => path.join(dirname, file))
+            // if the import does not end with .d.ts, it is a directory import
+            .map(file => file.endsWith('.d.ts') ? file : path.join(file, 'index.d.ts'))
+            // Find all libs we have not loaded yet
+            .filter(file => !(file in ret))
+            .forEach(file => definitionQueue.push(file));
+    }
+    return ret;
+}
+
+
+/**
+ * Translates a script ID to a filename for the compiler
+ * @param {string} scriptID The ID of the script
+ */
+function scriptIdToTSFilename(scriptID) {
+    return scriptID.replace(/^script.js./, '').replace(/\./g, '/') + '.ts';
+}
+
+module.exports = {
+    scriptIdToTSFilename,
+    resolveTypescriptLibs,
+    resolveTypings
+};


### PR DESCRIPTION
Before:
![grafik](https://user-images.githubusercontent.com/17641229/67376537-9a04ba00-f584-11e9-8d5b-063f00e84944.png)

After:
![grafik](https://user-images.githubusercontent.com/17641229/67376476-7fcadc00-f584-11e9-80bd-1dd5de0ad99c.png)

This also means that the script compiler will now find errors in scripts that come from wrong usage of 3rd party libraries.

**Known caveats:**
* Requires modules to have their own definitions (like axios)
* or users to install the definitions in the adapter settings (e.g. `@types/request`)

This PR is built on #419, so merge that one first