### PR TITLE
Add opt-in for syntax help for third party packages to config dialog

### DIFF
--- a/admin/index_m.html
+++ b/admin/index_m.html
@@ -220,6 +220,7 @@
 
         showHideSettings();
         list2chips('.libraries', settings.libraries || '', onChange);
+        list2chips('.libraryTypings', settings.libraryTypings || '', onChange);
 
         $('.tab-astro').on('click', function () {
             updateMap();
@@ -306,6 +307,7 @@
             }
         });
         obj.libraries = chips2list('.libraries');
+        obj.libraryTypings = chips2list('.libraryTypings');
 
         if (obj.latitude.indexOf('°') !== -1) {
             if (!convertGrad(obj, 'latitude')) {
@@ -353,6 +355,12 @@
                 <div class="col s12">
                     <label class="translate">Additional npm modules:</label>
                     <div class="chips libraries"></div>
+                </div>
+            </div>
+            <div class="row">
+                <div class="col s12">
+                    <label class="translate">Activate syntax help for these npm modules:</label>
+                    <div class="chips libraryTypings"></div>
                 </div>
             </div>
             <div class="row">

--- a/io-package.json
+++ b/io-package.json
@@ -160,7 +160,7 @@
         "enableSendToHost": false,
         "enableExec": false,
         "libraries": "",
-        "library-typings": "",
+        "libraryTypings": "",
         "subscribe": false,
         "useSystemGPS": true,
         "mirrorPath": "",

--- a/io-package.json
+++ b/io-package.json
@@ -160,6 +160,7 @@
         "enableSendToHost": false,
         "enableExec": false,
         "libraries": "",
+        "library-typings": "",
         "subscribe": false,
         "useSystemGPS": true,
         "mirrorPath": "",

--- a/main.js
+++ b/main.js
@@ -168,11 +168,21 @@ function loadTypeScriptDeclarations() {
         'node', // this provides auto completion for most builtins
         'request', // preloaded by the adapter
     ];
-    // Also include user-selected libraries
-    if (adapter.config && typeof adapter.config.libraries === 'string') {
-        const libraries = adapter.config.libraries.split(/[,;\s]+/).map(s => s.trim());
-        for (const lib of libraries) {
-            if (packages.indexOf(lib) === -1) packages.push(lib);
+    // Also include user-selected libraries (but only those that are also installed)
+    if (
+        adapter.config
+        && typeof adapter.config.libraries === 'string'
+        && typeof adapter.config.libraryTypings === 'string'
+    ) {
+        const installedLibs = adapter.config.libraries.split(/[,;\s]+/).map(s => s.trim());
+        const wantsTypings = adapter.config.libraryTypings.split(/[,;\s]+/).map(s => s.trim());
+        for (const lib of installedLibs) {
+            if (
+                wantsTypings.indexOf(lib) > -1
+                && packages.indexOf(lib) === -1
+            ) {
+                packages.push(lib);
+            }
         }
     }
     for (const pkg of packages) {


### PR DESCRIPTION
As written in #438 some typings (e.g. `googleapis`) require quite a lot of RAM. Thus we now require users to opt-in for which modules they want syntax help:

![grafik](https://user-images.githubusercontent.com/17641229/68086238-d7e9c400-fe49-11e9-9515-ef113d0e4149.png)
