### PR TITLE
fix MIME type application/zip not being accepted in react-dropzone

### DIFF
--- a/src/src/Dialogs/ImportFile.js
+++ b/src/src/Dialogs/ImportFile.js
@@ -160,7 +160,7 @@ class DialogImportFile extends React.Component {
                                 rejectClassName={classes.dropzoneRejected}
                                 onDrop={files => this.handleDropFile(files)}
                                 multiple={false}
-                                accept='application/x-zip-compressed'
+                                accept='application/zip,application/x-zip-compressed'
                                 className={className}>
                         {
                             ({ getRootProps, getInputProps, isDragActive, isDragReject}) => {


### PR DESCRIPTION
see #404 

I tested this by manually editing webpacked files in node_modules and iobroker-data - not the nicest way but it worked. The result was that I was able to upload ZIP files from an Ubuntu Linux client. Nevertheless, before dropping the file, the white cross still appeared.

The problem is that different OSes assign different MIME types to files. Windows seems to use application/x-zip-compressed for ZIP files, Linux uses application/zip