### PR TITLE
fix cacheObjectEnums

### DIFF
--- a/lib/eventObj.js
+++ b/lib/eventObj.js
@@ -1,17 +1,20 @@
 'use strict';
-const cacheObjectEnums = {};
 let inited = false;
 
 function getObjectEnumsSync(context, idObj, enumIds, enumNames) {
     if (!enumIds)   enumIds   = [];
     if (!enumNames) enumNames = [];
 
-    if (cacheObjectEnums[idObj]) {
-        for (let j = 0; j < cacheObjectEnums[idObj].enumIds.length; j++) {
-            if (enumIds.indexOf(cacheObjectEnums[idObj].enumIds[j]) === -1) enumIds.push(cacheObjectEnums[idObj].enumIds[j]);
+    if (context.cacheObjectEnums[idObj]) {
+        for (const enumId of context.cacheObjectEnums[idObj].enumIds) {
+            if (!enumIds.includes(enumId)) {
+                enumIds.push(enumId);
+            }
         }
-        for (let j = 0; j < cacheObjectEnums[idObj].enumNames.length; j++) {
-            if (enumNames.indexOf(cacheObjectEnums[idObj].enumNames[j]) === -1) enumNames.push(cacheObjectEnums[idObj].enumNames[j]);
+        for (const enumName of context.cacheObjectEnums[idObj].enumNames) {
+            if (!enumNames.includes(enumName)) {
+                enumNames.push(enumName);
+            }
         }
         return {enumIds: enumIds, enumNames: enumNames};
     }
@@ -32,13 +35,26 @@ function getObjectEnumsSync(context, idObj, enumIds, enumNames) {
         if (pos !== -1) {
             const parent = idObj.substring(0, pos);
             if (parent && context.objects[parent]) {
-                return getObjectEnumsSync(context, parent, enumIds, enumNames);
+                const parentEnumIds = [];
+                const parentEnumNames = [];
+                //get parent enums but do not propagate our enums to parent.
+                getObjectEnumsSync(context, parent, parentEnumIds, parentEnumNames);
+                for (const enumId of parentEnumIds) {
+                    if (!enumIds.includes(enumId)) {
+                        enumIds.push(enumId);
+                    }
+                }
+                for (const enumName of parentEnumNames) {
+                    if (!enumNames.includes(enumName)) {
+                        enumNames.push(enumName);
+                    }
+                }
             }
         }
     }
 
-    cacheObjectEnums[idObj] = {enumIds: enumIds, enumNames: enumNames};
-    return cacheObjectEnums[idObj];
+    context.cacheObjectEnums[idObj] = {enumIds: enumIds, enumNames: enumNames};
+    return context.cacheObjectEnums[idObj];
 }
 
 function doGetter(obj, name, ret) {


### PR DESCRIPTION
Cache of enum objects was broken. The "return" for parent prevented it to be filled for every child objects at all. If for all parts in a path objects were defined (i.e. instance, device, channel, ..., state), then the cache only got entries for the instance.

By handing the child enumId arrays to the parent, those cache entries were filled with the enums of the first child object processed (which is random). That explains the errounous behaviour that some users (including me) experienced.

Also the cache was declared locally and therefore never cleared. I.e. changes in enums would not be reflected. There was a global cache that already is cleared in onObjectChange in main.js, but it was never used.

Fixes #523 (tested by me) and might fix #515.
Might also fixes #466 , #364