### PR TITLE
Update mirror.js: Fix type error

### DIFF
--- a/lib/mirror.js
+++ b/lib/mirror.js
@@ -24,6 +24,15 @@ class Mirror {
         this.from       = 'system.adapter.' + this.adapter.namespace;
         this.lastSyncID = this.from + '.lastSync';
 
+        this.log = options.log || {
+            silly: text  => console.log(text),
+            debug: text  => console.log(text),
+            info:  text  => console.log(text),
+            log:   text  => console.log(text),
+            warn:  text  => console.warn(text),
+            error: text  => console.error(text)
+        };        
+        
         if (!fs.existsSync(this.diskRoot)) {
             try {
                 fs.mkdirSync(this.diskRoot);
@@ -32,15 +41,6 @@ class Mirror {
                 return;
             }
         }
-
-        this.log = options.log || {
-            silly: text  => console.log(text),
-            debug: text  => console.log(text),
-            info:  text  => console.log(text),
-            log:   text  => console.log(text),
-            warn:  text  => console.warn(text),
-            error: text  => console.error(text)
-        };
 
         this.diskList = this.scanDisk();
         this.checkLastSyncObject(lastSyncTime => {


### PR DESCRIPTION
**Change:** Assign `this.log` before calling `if (!fs.existsSync(this.diskRoot)) {`

**Reason:** Once line 31 `this.log.error('Cannot create directory ${this.diskRoot}: ${e}');` is executed, the adapter crashes.

**My system:** Debian | js-controller: 3.0.18 | node.js 12.16.1 |  tested JS adapter versions 4.5.1 & 4.6.0

```
2020-04-25 18:15:06.703 - error: host.ctioBroker Caught by controller[0]: This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). The promise rejected with the reason:
2020-04-25 18:15:06.703 - error: host.ctioBroker Caught by controller[1]: TypeError: Cannot read property 'error' of undefined
2020-04-25 18:15:06.704 - error: host.ctioBroker Caught by controller[1]: at new Mirror (/opt/iobroker/node_modules/iobroker.javascript/lib/mirror.js:31:14)
2020-04-25 18:15:06.704 - error: host.ctioBroker Caught by controller[1]: at /opt/iobroker/node_modules/iobroker.javascript/main.js:609:38
2020-04-25 18:15:06.704 - error: host.ctioBroker Caught by controller[1]: at _0x476a77._applyViewFunc (/opt/iobroker/node_modules/iobroker.objects-redis/index.js:1:115716)
2020-04-25 18:15:06.705 - error: host.ctioBroker Caught by controller[1]: at processTicksAndRejections (internal/process/task_queues.js:97:5)
```