### PR TITLE
mirror: fix crash if tailing slash is in path

### DIFF
--- a/lib/mirror.js
+++ b/lib/mirror.js
@@ -21,6 +21,10 @@ class Mirror {
         this.adapter = options.adapter;
         this.watchedFolder = {};
         this.diskRoot = path.normalize(options.diskRoot).replace(/\\/g, '/');
+        //remove tailing slash, causes off-by-one error in id in scanDisk otherwise which causes adapter to crash on start.
+        if (this.diskRoot.charAt(this.diskRoot.length -1) === "/") {
+            this.diskRoot = this.diskRoot.substring(0, this.diskRoot.length - 1);
+        }
         this.from       = 'system.adapter.' + this.adapter.namespace;
         this.lastSyncID = this.from + '.lastSync';
 

--- a/lib/mirror.js
+++ b/lib/mirror.js
@@ -21,10 +21,6 @@ class Mirror {
         this.adapter = options.adapter;
         this.watchedFolder = {};
         this.diskRoot = path.normalize(options.diskRoot).replace(/\\/g, '/');
-        //remove tailing slash, causes off-by-one error in id in scanDisk otherwise which causes adapter to crash on start.
-        if (this.diskRoot.charAt(this.diskRoot.length -1) === "/") {
-            this.diskRoot = this.diskRoot.substring(0, this.diskRoot.length - 1);
-        }
         this.from       = 'system.adapter.' + this.adapter.namespace;
         this.lastSyncID = this.from + '.lastSync';
 
@@ -505,8 +501,7 @@ class Mirror {
                 if (stats.isDirectory()) {
                     this.scanDisk(fullName.replace(/\\/g, '/'), list);
                 } else if (file.match(/\.js$|\.ts$/)) {
-                    let f = fullName.replace(/[\\/]/g, '.');
-                    f = 'script.js.' + f.substring(this.diskRoot.length + 1).replace(/\.js$|\.ts$/g, '');
+                    let f = this._fileName2scriptId(fullName);
                     list[f] = {ts: Math.round(stats.mtime), source: fs.readFileSync(fullName).toString(), name: fullName};
                 }
             });


### PR DESCRIPTION
if you have a tailing slash in diskRoot config variable this will cause a crash on adapter start with the following message
"uncaught exception: Cannot read property 'ts' of undefined" pointing to line 214 in mirror.js like reported in issue #551 

The trailing slash will cause an off by one error here:
https://github.com/ioBroker/ioBroker.javascript/blob/master/lib/mirror.js#L505
-> i.e. the first letter of the id goes missing there, so this.diskList get's filled with wrong keys and causes this.diskList[id] to be undefined in sync later, which is not expected to happen (also sync won't work properly with the wrong ids, if you fix the crash in line 214).