### PR TITLE
diverse mirror fixes

### DIFF
--- a/lib/mirror.js
+++ b/lib/mirror.js
@@ -456,8 +456,8 @@ class Mirror {
                         this.log.error('Cannot delete ' + file + ': ' + e);
                     }
                 }
-                if (this.diskList[file]) {
-                    delete this.diskList[file];
+                if (this.diskList[id]) {
+                    delete this.diskList[id];
                 }
             }
         } else if (obj.type === 'script' && id.startsWith('script.js.')) {
@@ -470,7 +470,7 @@ class Mirror {
                     this.dbList[id] = obj;
                     this.log.debug('Update ' + file + ' on disk');
                     fs.writeFileSync(file, obj.common.source, {mode: MODE_0777});
-                    this.diskList[file] = {ts: Date.now(), source: obj.common.source};
+                    this.diskList[id] = {ts: Date.now(), source: obj.common.source, name: file};
                 } else if (!this.diskList[id] || this.diskList[id].source !== obj.common.source) {
                     this.log.debug('Update ' + file + ' on disk');
                     fs.writeFileSync(file, obj.common.source, {mode: MODE_0777});

--- a/lib/mirror.js
+++ b/lib/mirror.js
@@ -160,15 +160,6 @@ class Mirror {
         }
     }
 
-    // create the folder recursively if not exists
-    static createRecursiveDir(dirDisk) {
-        try {
-            fs.mkdirSync(dirDisk, {recursive: true, mode: MODE_0777});
-        } catch (e) {
-            this.log.error(`Cannot create folder ${dirDisk}: ${e}`);
-        }
-    }
-
     _getFilesInPath(pathDisk) {
         pathDisk = pathDisk.substring(this.diskRoot.length + 1);
         const id = pathDisk.replace(/\./g, '\\.').replace(/[/\\]/g, '\\.');
@@ -189,6 +180,8 @@ class Mirror {
     _writeFile(id) {
         const diskListEntry = this.diskList[id];
         try {
+            //check if directory exists and create if not:
+            fs.mkdirSync(path.dirname(diskListEntry.name), {recursive: true, mode: MODE_0777});
             fs.writeFileSync(diskListEntry.name, diskListEntry.source, {mode: MODE_0777});
             diskListEntry.ts = Date.now();
             return true;
@@ -229,7 +222,6 @@ class Mirror {
                             this.dbList[id].ts = Date.now();
                             this.diskList[id].source = this.dbList[id].common.source;
                             this.log.debug('Update disk with ' + this.diskList[id].name);
-                            Mirror.createRecursiveDir(dirDisk);
                             this._writeFile(id);
                         } else if (this.dbList[id].ts && this.diskList[id].ts - this.dbList[id].ts > 2000) {
                             // copy file to DB
@@ -251,7 +243,6 @@ class Mirror {
         for (let o = objects.length - 1; o >= 0; o--) {
             const fileName = this._scriptId2FileName(dirDB + '.' + objects[o], this.dbList[dirDB + '.' + objects[o]].common.engineType);
             this.log.info('Created script file on disk ' + fileName);
-            Mirror.createRecursiveDir(dirDisk);
             const f = 'script.js.' + fileName.substring(this.diskRoot.length).replace(/[\\/]/g, '.').replace(/\.js$|\.ts$/g, '');
             this.diskList[f] = {name: fileName, source: this.dbList[dirDB + '.' + objects[o]].common.source, ts: 0};
             this._writeFile(f);
@@ -470,10 +461,6 @@ class Mirror {
             }
         } else if (obj.type === 'script' && id.startsWith('script.js.')) {
             if (this.dbList[id]) {
-                const folderDirParts = file.split(/[\\/]/);
-                folderDirParts.pop();
-                Mirror.createRecursiveDir(folderDirParts.join('/'));
-
                 if (this.dbList[id].common.source !== obj.common.source) {
                     this.dbList[id] = obj;
                     this.log.debug('Update ' + file + ' on disk');
@@ -488,9 +475,6 @@ class Mirror {
                 // new script
                 this.dbList[id] = obj;
                 if (!this.diskList[id] || this.diskList[id].source !== obj.common.source) {
-                    const folderDirParts = file.split(/[\\/]/);
-                    folderDirParts.pop();
-                    Mirror.createRecursiveDir(folderDirParts.join('/'));
                     this.log.debug('Create ' + file + ' on disk');
                     this.diskList[id] = {ts: 0, source: obj.common.source, name: file};
                     this._writeFile(id);

--- a/lib/mirror.js
+++ b/lib/mirror.js
@@ -164,17 +164,12 @@ class Mirror {
         }
     }
 
-    // TODO: node.js supports mkdirSync('filter/folder', {recursive: true}) => rewrite
     // create the folder recursively if not exists
     static createRecursiveDir(dirDisk) {
-        const parts = dirDisk.replace(/\\/g, '/').split('/');
-        let path = '';
-        for (let i = 0; i < parts.length; i++) {
-            path += (i > 0 ? '/' : '') + parts[i];
-            // if not C: and not exists
-            if (path && !parts[i].includes(':') && !fs.existsSync(path)) {
-                fs.mkdirSync(path, {mode: MODE_0777});
-            }
+        try {
+            fs.mkdirSync(dirDisk, {recursive: true, mode: MODE_0777});
+        } catch (e) {
+            this.log.error(`Cannot create folder ${dirDisk}: ${e}`);
         }
     }
 

--- a/lib/mirror.js
+++ b/lib/mirror.js
@@ -130,7 +130,7 @@ class Mirror {
         if (pos !== -1) {
             data = data.substring(pos + 1);
             if (data[0] === '/' && data[1] === '/') {
-                data = Buffer(data.substring(2), 'base64').toString('utf8');
+                data = Buffer.from(data.substring(2), 'base64').toString('utf8');
                 if (data.startsWith('%3Cxml')) {
                     return true;
                 }

--- a/lib/mirror.js
+++ b/lib/mirror.js
@@ -21,6 +21,10 @@ class Mirror {
         this.adapter = options.adapter;
         this.watchedFolder = {};
         this.diskRoot = path.normalize(options.diskRoot).replace(/\\/g, '/');
+        //remove tailing slash, causes off-by-one error in id in scanDisk otherwise which causes adapter to crash on start.
+        if (this.diskRoot.charAt(this.diskRoot.length -1) === "/") {
+            this.diskRoot = this.diskRoot.substring(0, this.diskRoot.length - 1);
+        }
         this.from       = 'system.adapter.' + this.adapter.namespace;
         this.lastSyncID = this.from + '.lastSync';
 

--- a/lib/mirror.js
+++ b/lib/mirror.js
@@ -21,10 +21,6 @@ class Mirror {
         this.adapter = options.adapter;
         this.watchedFolder = {};
         this.diskRoot = path.normalize(options.diskRoot).replace(/\\/g, '/');
-        //remove tailing slash, causes off-by-one error in id in scanDisk otherwise which causes adapter to crash on start.
-        if (this.diskRoot.charAt(this.diskRoot.length -1) === "/") {
-            this.diskRoot = this.diskRoot.substring(0, this.diskRoot.length - 1);
-        }
         this.from       = 'system.adapter.' + this.adapter.namespace;
         this.lastSyncID = this.from + '.lastSync';
 
@@ -517,8 +513,7 @@ class Mirror {
                 if (stats.isDirectory()) {
                     this.scanDisk(fullName.replace(/\\/g, '/'), list);
                 } else if (file.match(/\.js$|\.ts$/)) {
-                    let f = fullName.replace(/[\\/]/g, '.');
-                    f = 'script.js.' + f.substring(this.diskRoot.length + 1).replace(/\.js$|\.ts$/g, '');
+                    let f = this._fileName2scriptId(fullName);
                     list[f] = {ts: Math.round(stats.mtime), source: fs.readFileSync(fullName).toString(), name: fullName};
                 }
             });

--- a/lib/mirror.js
+++ b/lib/mirror.js
@@ -184,6 +184,24 @@ class Mirror {
         return Object.keys(this.dbList).filter(id => reg.test(id)).map(id => id.split('.').pop());
     }
 
+    /**
+     * Write file to disk, synchron, catch (and print) error.
+     * @param {string} id of script
+     * @returns {boolean} true if write was successful
+     * @private
+     */
+    _writeFile(id) {
+        const diskListEntry = this.diskList[id];
+        try {
+            fs.writeFileSync(diskListEntry.name, diskListEntry.source, {mode: MODE_0777});
+            diskListEntry.ts = Date.now();
+            return true;
+        } catch (e) {
+            this.log.error(`Cannot write file ${diskListEntry ? diskListEntry.name : id}: ${e}`);
+            return false;
+        }
+    }
+
     sync(lastSyncTime, pathDisk, pathDB) {
         lastSyncTime = lastSyncTime || 0;
         pathDisk = pathDisk || [];
@@ -214,10 +232,9 @@ class Mirror {
                             // copy text to file
                             this.dbList[id].ts = Date.now();
                             this.diskList[id].source = this.dbList[id].common.source;
-                            this.diskList[id].ts = Date.now();
                             this.log.debug('Update disk with ' + this.diskList[id].name);
                             Mirror.createRecursiveDir(dirDisk);
-                            fs.writeFileSync(this.diskList[id].name, this.dbList[id].common.source, {mode: MODE_0777});
+                            this._writeFile(id);
                         } else if (this.dbList[id].ts && this.diskList[id].ts - this.dbList[id].ts > 2000) {
                             // copy file to DB
                             this.dbList[id].common.source = this.diskList[id].source;
@@ -240,8 +257,8 @@ class Mirror {
             this.log.info('Created script file on disk ' + fileName);
             Mirror.createRecursiveDir(dirDisk);
             const f = 'script.js.' + fileName.substring(this.diskRoot.length).replace(/[\\/]/g, '.').replace(/\.js$|\.ts$/g, '');
-            this.diskList[f] = {name: fileName, source: this.dbList[dirDB + '.' + objects[o]].common.source, ts: Date.now()};
-            fs.writeFileSync(fileName, this.dbList[dirDB + '.' + objects[o]].common.source, {mode: MODE_0777});
+            this.diskList[f] = {name: fileName, source: this.dbList[dirDB + '.' + objects[o]].common.source, ts: 0};
+            this._writeFile(f);
         }
 
         // go through files, that does not exist in DB
@@ -464,12 +481,12 @@ class Mirror {
                 if (this.dbList[id].common.source !== obj.common.source) {
                     this.dbList[id] = obj;
                     this.log.debug('Update ' + file + ' on disk');
-                    fs.writeFileSync(file, obj.common.source, {mode: MODE_0777});
-                    this.diskList[id] = {ts: Date.now(), source: obj.common.source, name: file};
+                    this.diskList[id] = {ts: 0, source: obj.common.source, name: file};
+                    this._writeFile(id);
                 } else if (!this.diskList[id] || this.diskList[id].source !== obj.common.source) {
                     this.log.debug('Update ' + file + ' on disk');
-                    fs.writeFileSync(file, obj.common.source, {mode: MODE_0777});
-                    this.diskList[id] = {ts: Date.now(), source: obj.common.source, name: file};
+                    this.diskList[id] = {ts: 0, source: obj.common.source, name: file};
+                    this._writeFile(id);
                 }
             } else {
                 // new script
@@ -479,8 +496,8 @@ class Mirror {
                     folderDirParts.pop();
                     Mirror.createRecursiveDir(folderDirParts.join('/'));
                     this.log.debug('Create ' + file + ' on disk');
-                    fs.writeFileSync(file, obj.common.source, {mode: MODE_0777});
-                    this.diskList[id] = {ts: Date.now(), source: obj.common.source, name: file};
+                    this.diskList[id] = {ts: 0, source: obj.common.source, name: file};
+                    this._writeFile(id);
                 }
             }
             this.dbList[id].ts = Date.now();

--- a/lib/mirror.js
+++ b/lib/mirror.js
@@ -240,7 +240,7 @@ class Mirror {
             const fileName = this._scriptId2FileName(dirDB + '.' + objects[o], this.dbList[dirDB + '.' + objects[o]].common.engineType);
             this.log.info('Created script file on disk ' + fileName);
             Mirror.createRecursiveDir(dirDisk);
-            const f = 'script.js.' + fileName.substring(this.diskRoot.length).replace(/[\\/]g/, '.').replace(/\.js$|\.ts$/g, '');
+            const f = 'script.js.' + fileName.substring(this.diskRoot.length).replace(/[\\/]/g, '.').replace(/\.js$|\.ts$/g, '');
             this.diskList[f] = {name: fileName, source: this.dbList[dirDB + '.' + objects[o]].common.source, ts: Date.now()};
             fs.writeFileSync(fileName, this.dbList[dirDB + '.' + objects[o]].common.source, {mode: MODE_0777});
         }


### PR DESCRIPTION
This is an extended version of #550 - like #550 this should also fix #551 
I did some more fixes and cleanup in mirror.js. Those are not as critical and are not really complete, yet, but I lost time to finish them. So maybe it is a good idea to merge them and let me find time to continue improvements later (or somebody else).
Things changed / fixed:
- catch write errors
- fix crash on start in line 214 with .ts of undefined because of trailing slash in config and bogus ids for diskList
- fix some errors / oversights with disk-ids in sync 
- fixed typo in some Regex which also caused disk-ids to go bogus
- replaced deprecated use of new Buffer
- rewrote createRecursiveDir to use node.js functionality (as per TODO comment)

Todo List:
- catch all read errors
- investigate possible issues and implement mirroring on multiple instances (at least on different hosts), probably including test cases.