### PR TITLE
Fixes for type definition resolution

### DIFF
--- a/lib/typescriptTools.js
+++ b/lib/typescriptTools.js
@@ -87,9 +87,10 @@ function resolveTypings(pkg, wrapInDeclareModule) {
         ...matchAll(pathReferenceRegex, string)
     ].map(groups => groups[0]);
 
-    // some @types packages specify `index` as their typings file instead of `index.d.ts`
-    if (!rootTypings.endsWith('.d.ts')) rootTypings += '.d.ts';
+    // the paths are relative to the package.json - we need an absolute path to read the files
     rootTypings = path.join(packageRoot, rootTypings);
+    // some @types packages specify `index` as their typings file instead of `index.d.ts`
+    rootTypings = normalizeDTSImport(rootTypings);
 
     // recursively load all typings
     const definitionQueue = [rootTypings];

--- a/lib/typescriptTools.js
+++ b/lib/typescriptTools.js
@@ -49,34 +49,38 @@ function normalizeDTSImport(filename) {
  */
 function resolveTypings(pkg, wrapInDeclareModule) {
     let packageJsonPath;
-    // First, try to resolve the package itself in case it brings its own typings
-    try {
-        packageJsonPath = require.resolve(`${pkg}/package.json`);
-    } catch (e) {
-        // If that didn't work, try again with the @types version of the package
-        try {
-            packageJsonPath = require.resolve(`@types/${pkg}/package.json`);
-        } catch (e) {
-            // TODO: download @types/<packagename>
-            return {};
-        }
-    }
-    const packageJson = require(packageJsonPath);
-
+    let packageJson;
     /** @type {string | undefined} */
-    let rootTypings = typeof packageJson.types === 'string' ? packageJson.types
-        : typeof packageJson.typings === 'string' ? packageJson.typings
-            : undefined;
-    if (!rootTypings) {
-        return {};
+    let rootTypings;
+
+    /**
+     * @param {string} path
+     */
+    function tryToLoadPackage(path) {
+        try {
+            packageJsonPath = require.resolve(path);
+            packageJson = require(packageJsonPath);
+            rootTypings = typeof packageJson.types === 'string' ? packageJson.types
+                : typeof packageJson.typings === 'string' ? packageJson.typings
+                    : undefined;
+        } catch { /* ignore */ }
     }
+
+    // First, try to resolve the package itself in case it brings its own typings
+    tryToLoadPackage(`${pkg}/package.json`);
+    // If that didn't work, try again with the @types version of the package
+    if (!rootTypings) tryToLoadPackage(`@types/${pkg}/package.json`);
+    // TODO: If that didn't work, download @types/<packagename> and retry the previous step
+
+    // Nothing to do here since we found no packages
+    if (!rootTypings) return {};
 
     const packageRoot = path.dirname(packageJsonPath);
 
     const ret = {};
 
-    // We need to look at `import ... from 'modulename'` and `/// <reference path='...' />`
-    const importDtsRegex = /import .+ from ["'](\.\/[^"']+)["']/g;
+    // We need to look at `import/export ... from 'modulename'` and `/// <reference path='...' />`
+    const importDtsRegex = /(?:import|export) .+ from ["'](\.\/[^"']+)["']/g;
     const pathReferenceRegex = /\/\/\/ <reference path=["']([^"']+)["'] \/>/g;
     const matchAllImports = string => [
         ...matchAll(importDtsRegex, string),

--- a/lib/typescriptTools.js
+++ b/lib/typescriptTools.js
@@ -52,6 +52,7 @@ function resolveTypings(pkg, wrapInDeclareModule) {
     let packageJson;
     /** @type {string | undefined} */
     let rootTypings;
+    let pkgIncludesTypings = true;
 
     /**
      * @param {string} path
@@ -69,7 +70,10 @@ function resolveTypings(pkg, wrapInDeclareModule) {
     // First, try to resolve the package itself in case it brings its own typings
     tryToLoadPackage(`${pkg}/package.json`);
     // If that didn't work, try again with the @types version of the package
-    if (!rootTypings) tryToLoadPackage(`@types/${pkg}/package.json`);
+    if (!rootTypings) {
+        tryToLoadPackage(`@types/${pkg}/package.json`);
+        pkgIncludesTypings = false;
+    }
     // TODO: If that didn't work, download @types/<packagename> and retry the previous step
 
     // Nothing to do here since we found no packages
@@ -92,6 +96,10 @@ function resolveTypings(pkg, wrapInDeclareModule) {
     // some @types packages specify `index` as their typings file instead of `index.d.ts`
     rootTypings = normalizeDTSImport(rootTypings);
 
+    // include package.json in typings, so TypeScript can look up the correct entry point
+    const relativePath = `node_modules/${pkgIncludesTypings ? '' : '@types/'}${pkg}/package.json`.replace(/\\/g, '/');
+    ret[relativePath] = JSON.stringify(packageJson);
+
     // recursively load all typings
     const definitionQueue = [rootTypings];
     while (definitionQueue.length > 0) {
@@ -108,9 +116,9 @@ function resolveTypings(pkg, wrapInDeclareModule) {
             return {};
         }
         // We need to store the filename relative to the base dir
-        const relativePath = `@types/${pkg}/${path.relative(packageRoot, filename)}`.replace(/\\/g, '/');
+        const relativePath = `node_modules/${pkgIncludesTypings ? '' : '@types/'}${pkg}/${path.relative(packageRoot, filename)}`.replace(/\\/g, '/');
         // If necessary, wrap the root typings (only those!)
-        ret[relativePath] = wrapInDeclareModule && filename === rootTypings
+        ret[relativePath] = !pkgIncludesTypings && wrapInDeclareModule && filename === rootTypings
             ? `declare module "${pkg}" { ${fileContent} }`
             : fileContent;
         // If this file references another .d.ts file, we need to load that too

--- a/package-lock.json
+++ b/package-lock.json
@@ -5928,9 +5928,9 @@
       }
     },
     "virtual-tsc": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/virtual-tsc/-/virtual-tsc-0.6.0.tgz",
-      "integrity": "sha512-tz4u/bBnQ65ckwd6Vsf676sWm+kwLAXPgH+k0S64o+ktT4CkodPH4ZtaQwwcqfOdNNizu9MIia8AWPNp9tk/DQ==",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/virtual-tsc/-/virtual-tsc-0.6.1.tgz",
+      "integrity": "sha512-I3K/Tvm6AklqyCRvFwz0Aiq9R/dad3GX7n8bCVfoQo6LRrWQVVWbBoAoOr4/We6fbRmlEY+LcC73ZUh7hQdE2A==",
       "requires": {
         "colors": "^1.3.0",
         "debug": "^3.1.0"

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
         "semver": "^7.3.2",
         "suncalc2": "^1.8.1",
         "typescript": "^3.9.2",
-        "virtual-tsc": "^0.6.0",
+        "virtual-tsc": "^0.6.1",
         "wake_on_lan": "^1.0.0"
     },
     "devDependencies": {


### PR DESCRIPTION
This PR includes 3 fixes to our type definition resolution algorithm
* we now correctly determine the type declaration paths of modules that use `export ... from` syntax.
* When package.json is found, but includes no typings, we now actually try to load `@types/packagename`. Previously this was not done because the fallback was in the wrong place.
* When a package.json references a directory in its `"types"` entry, the correct `index.d.ts` file is now read.

fixes: https://github.com/ioBroker/ioBroker.javascript/issues/130
fixes: https://forum.iobroker.net/topic/34797/npm-registry-umstellen/10