### PR TITLE
Fix type resolution for rxjs in TypeScripts

### DIFF
--- a/lib/typescriptTools.js
+++ b/lib/typescriptTools.js
@@ -80,11 +80,14 @@ function resolveTypings(pkg, wrapInDeclareModule) {
     if (!rootTypings) return {};
 
     const packageRoot = path.dirname(packageJsonPath);
+    const normalizeImportPath = filename => path.normalize(
+        `node_modules/${pkgIncludesTypings ? '' : '@types/'}${pkg}/${path.relative(packageRoot, filename)}`
+    ).replace(/\\/g, '/');
 
     const ret = {};
 
     // We need to look at `import/export ... from 'modulename'` and `/// <reference path='...' />`
-    const importDtsRegex = /(?:import|export) .+ from ["'](\.\/[^"']+)["']/g;
+    const importDtsRegex = /(?:import|export) .+ from ["'](\.+\/[^"']+)["']/g;
     const pathReferenceRegex = /\/\/\/ <reference path=["']([^"']+)["'] \/>/g;
     const matchAllImports = string => [
         ...matchAll(importDtsRegex, string),
@@ -99,6 +102,9 @@ function resolveTypings(pkg, wrapInDeclareModule) {
     // include package.json in typings, so TypeScript can look up the correct entry point
     const relativePath = `node_modules/${pkgIncludesTypings ? '' : '@types/'}${pkg}/package.json`.replace(/\\/g, '/');
     ret[relativePath] = JSON.stringify(packageJson);
+
+    // Used to test whether a .d.ts file already uses "declare module" or not
+    const declareModuleRegex = /^\s*declare module/gm;
 
     // recursively load all typings
     const definitionQueue = [rootTypings];
@@ -116,9 +122,9 @@ function resolveTypings(pkg, wrapInDeclareModule) {
             return {};
         }
         // We need to store the filename relative to the base dir
-        const relativePath = `node_modules/${pkgIncludesTypings ? '' : '@types/'}${pkg}/${path.relative(packageRoot, filename)}`.replace(/\\/g, '/');
+        const relativePath = normalizeImportPath(filename);
         // If necessary, wrap the root typings (only those!)
-        ret[relativePath] = !pkgIncludesTypings && wrapInDeclareModule && filename === rootTypings
+        ret[relativePath] = wrapInDeclareModule && filename === rootTypings && !declareModuleRegex.test(fileContent)
             ? `declare module "${pkg}" { ${fileContent} }`
             : fileContent;
         // If this file references another .d.ts file, we need to load that too
@@ -128,7 +134,7 @@ function resolveTypings(pkg, wrapInDeclareModule) {
             // find out the correct path of the file we want to import
             .map(normalizeDTSImport)
             // Find all libs we have not loaded yet
-            .filter(file => !(file in ret))
+            .filter(file => !(normalizeImportPath(file) in ret))
             .forEach(file => definitionQueue.push(file));
     }
     return ret;

--- a/main.js
+++ b/main.js
@@ -180,9 +180,24 @@ function loadTypeScriptDeclarations() {
     ) {
         const installedLibs = adapter.config.libraries.split(/[,;\s]+/).map(s => s.trim());
         const wantsTypings = adapter.config.libraryTypings.split(/[,;\s]+/).map(s => s.trim());
+        // Add all installed libraries the user has requested typings for to the list of packages
         for (const lib of installedLibs) {
             if (
                 wantsTypings.indexOf(lib) > -1
+                && packages.indexOf(lib) === -1
+            ) {
+                packages.push(lib);
+            }
+        }
+        // Some packages have sub-modules (e.g. rxjs/operators) that are not exposed through the main entry point
+        // If typings are requested for them, also add them if the base module is installed
+        for (const lib of wantsTypings) {
+            // Extract the package name and check if we need to add it
+            if (lib.indexOf('/') === -1) continue;
+            const pkgName = lib.substr(0, lib.indexOf('/'));
+
+            if (
+                installedLibs.indexOf(pkgName) > -1
                 && packages.indexOf(lib) === -1
             ) {
                 packages.push(lib);


### PR DESCRIPTION
Fixes #618 

@agross this should fix your issue with rxjs. Using these settings, I can use rxjs and rxjs/operators in scripts:
![grafik](https://user-images.githubusercontent.com/17641229/90338438-f93b2b80-dfe9-11ea-8a8f-c03aa041e09d.png)
