### PR TITLE
Add xyzAsync methods and wait/sleep to the sandbox

### DIFF
--- a/lib/adapter-config.d.ts
+++ b/lib/adapter-config.d.ts
@@ -1,0 +1,16 @@
+// This file extends the AdapterConfig type from "@types/iobroker"
+// using the actual properties present in io-package.json
+// in order to provide typings for adapter.config properties
+
+import { native } from '../io-package.json';
+
+type _AdapterConfig = typeof native;
+
+// Augment the globally declared type ioBroker.AdapterConfig
+declare global {
+    namespace ioBroker {
+        interface AdapterConfig extends _AdapterConfig {
+            // Do not enter anything here!
+        }
+    }
+}

--- a/lib/sandbox.js
+++ b/lib/sandbox.js
@@ -4,8 +4,7 @@
 
 'use strict';
 
-const isObject = require('./tools').isObject;
-const isArray  = require('./tools').isArray;
+const { isObject, isArray, promisify } = require('./tools');
 
 // let context = {
 //     adapter,
@@ -699,8 +698,8 @@ function sandBox(script, name, verbose, debug, context) {
                 res = res.map(id => context.channels[id])
                     // and flatten the array to get only the state IDs
                     .reduce((acc, next) => acc.concat(next), []);
-                    // now filter out those that don't match every ID selector for the state ID
 
+                // now filter out those that don't match every ID selector for the state ID
                 if (stateIdSelectors.length) {
                     res = res.filter(stateId => applyIDSelectors(stateId, stateIdSelectors));
                 }
@@ -800,6 +799,13 @@ function sandBox(script, name, verbose, debug, context) {
                     return this[0] ? states[this[0]] : null;
                 }
             };
+            result.getStateAsync = function() {
+                if (adapter.config.subscribe) {
+                    return adapter.getForeignStateAsync(this[0]);
+                } else {
+                    return this[0] ? states[this[0]] : null;
+                }
+            };
             result.getBinaryState = function (callback) {
                 if (adapter.config.subscribe) {
                     if (typeof callback !== 'function') {
@@ -811,12 +817,24 @@ function sandBox(script, name, verbose, debug, context) {
                     return this[0] ? states[this[0]] : null;
                 }
             };
+            result.getBinaryStateAsync = function() {
+                if (adapter.config.subscribe) {
+                    return adapter.getBinaryStateAsync(this[0]);
+                } else {
+                    return this[0] ? states[this[0]] : null;
+                }
+            };
             result.setState = function (state, isAck, callback) {
                 if (typeof isAck === 'function') {
                     callback = isAck;
                     isAck = undefined;
                 }
-
+                result.setStateAsync(state, isAck).then(() => {
+                    if (typeof callback === 'function') callback();
+                });
+                return this;
+            };
+            result.setStateAsync = async function (state, isAck) {
                 if (isAck === true || isAck === false || isAck === 'true' || isAck === 'false') {
                     if (isObject(state)) {
                         state.ack = isAck;
@@ -824,21 +842,21 @@ function sandBox(script, name, verbose, debug, context) {
                         state = {val: state, ack: isAck};
                     }
                 }
-                let cnt = 0;
                 for (let i = 0; i < this.length; i++) {
-                    cnt++;
-                    adapter.setForeignState(this[i], state, function () {
-                        if (!--cnt && typeof callback === 'function') callback();
-                    });
+                    await adapter.setForeignStateAsync(this[i], state);
                 }
-                return this;
             };
             result.setBinaryState = function (state, isAck, callback) {
                 if (typeof isAck === 'function') {
                     callback = isAck;
                     isAck = undefined;
                 }
-
+                result.setBinaryStateAsync(state, isAck).then(() => {
+                    if (typeof callback === 'function') callback();
+                });
+                return this;
+            };
+            result.setBinaryStateAsync = async function (state, isAck) {
                 if (isAck === true || isAck === false || isAck === 'true' || isAck === 'false') {
                     if (isObject(state)) {
                         state.ack = isAck;
@@ -846,14 +864,9 @@ function sandBox(script, name, verbose, debug, context) {
                         state = {val: state, ack: isAck};
                     }
                 }
-                let cnt = 0;
                 for (let i = 0; i < this.length; i++) {
-                    cnt++;
-                    adapter.setBinaryState(this[i], state, function () {
-                        if (!--cnt && typeof callback === 'function') callback();
-                    });
+                    await adapter.setBinaryStateAsync(this[i], state);
                 }
-                return this;
             };
             result.on = function (callbackOrId, value) {
                 for (let i = 0; i < this.length; i++) {
@@ -1962,15 +1975,15 @@ function sandBox(script, name, verbose, debug, context) {
                 adapter.sendToHost(host, cmd, msg, callback);
             }
         },
-        setInterval:    function (callback, ms, arg1, arg2, arg3, arg4) {
+        setInterval:    function (callback, ms, ...args) {
             if (typeof callback === 'function') {
-                const int = setInterval(function (_arg1, _arg2, _arg3, _arg4) {
+                const int = setInterval(() => {
                     try {
-                        callback.call(sandbox, _arg1, _arg2, _arg3, _arg4);
+                        callback.call(sandbox, ...args);
                     } catch (e) {
                         errorInCallback(e); //adapter.log.error('Error in callback: ' + e)
                     }
-                }, ms, arg1, arg2, arg3, arg4);
+                }, ms);
                 script.intervals.push(int);
 
                 sandbox.verbose && sandbox.log('setInterval(ms=' + ms + ')', 'info');
@@ -1990,19 +2003,19 @@ function sandBox(script, name, verbose, debug, context) {
                 sandbox.verbose && sandbox.log('clearInterval() => not found', 'warn');
             }
         },
-        setTimeout:     function (callback, ms, arg1, arg2, arg3, arg4) {
+        setTimeout:     function (callback, ms, ...args) {
             if (typeof callback === 'function') {
-                const to = setTimeout(function (_arg1, _arg2, _arg3, _arg4) {
+                const to = setTimeout(() => {
                     // Remove timeout from the list
                     const pos = script.timeouts.indexOf(to);
                     if (pos !== -1) script.timeouts.splice(pos, 1);
 
                     try {
-                        callback.call(sandbox, _arg1, _arg2, _arg3, _arg4);
+                        callback.call(sandbox, ...args);
                     } catch (e) {
                         errorInCallback(e); //adapter.log.error('Error in callback: ' + e)
                     }
-                }, ms, arg1, arg2, arg3, arg4);
+                }, ms);
                 sandbox.verbose && sandbox.log('setTimeout(ms=' + ms + ')', 'info');
 
                 script.timeouts.push(to);
@@ -2022,15 +2035,15 @@ function sandBox(script, name, verbose, debug, context) {
                 sandbox.verbose && sandbox.log('clearTimeout() => not found', 'warn');
             }
         },
-        setImmediate:   function (callback, arg1, arg2, arg3, arg4, arg5) {
+        setImmediate:   function (callback, ...args) {
             if (typeof callback === 'function') {
-                setImmediate(function (_arg1, _arg2, _arg3, _arg4, _arg5) {
+                setImmediate(() => {
                     try {
-                        callback.call(sandbox, _arg1, _arg2, _arg3, _arg4, _arg5);
+                        callback.call(sandbox, ...args);
                     } catch (e) {
                         errorInCallback(e);
                     }
-                }, arg1, arg2, arg3, arg4, arg5);
+                });
                 sandbox.verbose && sandbox.log('setImmediate()', 'info');
             } else {
                 sandbox.log('Invalid callback for setImmediate! - ' + typeof callback, 'error');
@@ -2488,6 +2501,15 @@ function sandBox(script, name, verbose, debug, context) {
                 return true;
             }
         },
+        runScriptAsync: function (scriptName) {
+            return new Promise((resolve, reject) => {
+                const result = sandbox.runScript(scriptName, (err) => {
+                    if (err) reject(err);
+                    resolve();
+                });
+                if (result === false) reject(`Script ${scriptName} was not found!`);
+            });
+        },
         startScript:    function (scriptName, ignoreIfStarted, callback) {
             if (typeof ignoreIfStarted === 'function') {
                 callback = ignoreIfStarted;
@@ -2508,10 +2530,8 @@ function sandBox(script, name, verbose, debug, context) {
                         if (!ignoreIfStarted) {
                             objects[scriptName].common.enabled = false;
                             adapter.extendForeignObject(scriptName, {common: {enabled: false}}, () => {
-
                                 adapter.extendForeignObject(scriptName, {common: {enabled: true}}, err =>
                                     callback === 'function' && callback(err, true));
-
                                 scriptName = null;
                             });
                         } else if (callback === 'function') {
@@ -2525,6 +2545,15 @@ function sandBox(script, name, verbose, debug, context) {
                 }
                 return true;
             }
+        },
+        startScriptAsync: function (scriptName, ...args) {
+            return new Promise((resolve, reject) => {
+                const result = sandbox.startScript(scriptName, ...args, (err, started) => {
+                    if (err) reject(err);
+                    resolve(started);
+                });
+                if (result === false) reject(`Script ${scriptName} was not found!`);
+            });
         },
         stopScript:     function (scriptName, callback) {
             scriptName = scriptName || name;
@@ -2551,6 +2580,15 @@ function sandBox(script, name, verbose, debug, context) {
                 }
                 return true;
             }
+        },
+        stopScriptAsync: function (scriptName) {
+            return new Promise((resolve, reject) => {
+                const result = sandbox.stopScript(scriptName, (err, stopped) => {
+                    if (err) reject(err);
+                    resolve(stopped);
+                });
+                if (result === false) reject(`Script ${scriptName} was not found!`);
+            });
         },
         isScriptActive: function (scriptName) {
             if (!scriptName.match(/^script\.js\./)) scriptName = 'script.js.' + scriptName;
@@ -2742,6 +2780,14 @@ function sandBox(script, name, verbose, debug, context) {
         },
         jsonataExpression: function (data, expression) {
             return jsonata(expression).evaluate(data);
+        },
+        wait: function (ms) {
+            return new Promise(resolve => {
+                sandbox.setTimeout(() => resolve(), ms);
+            });
+        },
+        sleep: function (ms) {
+            return sandbox.wait(ms);
         }
     };
 
@@ -2803,14 +2849,36 @@ function sandBox(script, name, verbose, debug, context) {
         };
     }
 
+    // promisify methods on the sandbox
+    /** @type {(keyof typeof sandbox)[]} */
+    const promisifedMethods = [
+        'setState',
+        'setBinaryState',
+        'getState',
+        'getBinaryState',
+        'existsState',
+        'existsObject',
+        'getObject',
+        'setObject',
+        'extendObject',
+        'deleteObject',
+        'createState',
+        'deleteState',
+        'writeFile',
+        'readFile',
+        'unlink',
+        'delFile',
+    ];
+    for (const method of promisifedMethods) {
+        sandbox[`${method}Async`] = promisify(sandbox[method]);
+    }
+
     // Make all predefined properties and methods readonly so scripts cannot overwrite them
-    for (const prop in sandbox) {
-        if (sandbox.hasOwnProperty(prop)) {
-            Object.defineProperty(sandbox, prop, {
-                configurable: false,
-                writable: false
-            });
-        }
+    for (const prop of Object.keys(sandbox)) {
+        Object.defineProperty(sandbox, prop, {
+            configurable: false,
+            writable: false
+        });
     }
 
     return sandbox;

--- a/lib/tools.js
+++ b/lib/tools.js
@@ -6,6 +6,7 @@ const path = require('path');
 /**
  * Tests whether the given variable is a real object and not an Array
  * @param {any} it The variable to test
+ * @returns {it is Record<string, any>}
  */
 function isObject(it) {
     // This is necessary because:
@@ -18,6 +19,7 @@ function isObject(it) {
 /**
  * Tests whether the given variable is really an Array
  * @param {any} it The variable to test
+ * @returns {it is any[]}
  */
 function isArray(it) {
     if (Array.isArray != null) return Array.isArray(it);
@@ -64,10 +66,49 @@ function enumFilesRecursiveSync(rootDir, predicate) {
     return ret;
 }
 
+/**
+ * Promisifies a callback-style function with parameters (err, result)
+ * @param {(...args: any[]) => any} fn The callback-style function to promisify
+ * @param {*} [context] The value of `this` in the function
+ */
+function promisify(fn, context) {
+    return function(...args) {
+        // @ts-ignore We want this behavior
+        context = context || this;
+        return new Promise((resolve, reject) => {
+            fn.apply(context, [...args, (error, result) => {
+                if (error) {
+                    return reject(error);
+                } else {
+                    return resolve(result);
+                }
+            }]);
+        });
+    };
+}
+
+/**
+ * Promisifies a callback-style function without an error parameter
+ * @param {(...args: any[]) => any} fn The callback-style function to promisify
+ * @param {*} [context] The value of `this` in the function
+ */
+function promisifyNoError(fn, context) {
+    return function(...args) {
+        // @ts-ignore We want this behavior
+        context = context || this;
+        return new Promise((resolve) => {
+            fn.apply(context, [...args, (result) => {
+                return resolve(result);
+            }]);
+        });
+    };
+}
 
 module.exports = {
     isArray,
     isObject,
     matchAll,
-    enumFilesRecursiveSync
+    enumFilesRecursiveSync,
+    promisify,
+    promisifyNoError
 };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,33 @@
+{
+	"compileOnSave": true,
+	"compilerOptions": {
+		// do not compile anything, this file is just to configure type checking
+		"noEmit": true,
+
+		// check JS files
+		"allowJs": true,
+		"checkJs": true,
+
+		"module": "commonjs",
+		"moduleResolution": "node",
+		// this is necessary for the automatic typing of the adapter config
+		"resolveJsonModule": true,
+
+		// Set this to false if you want to disable the very strict rules (not recommended)
+		"strict": true,
+		// Or enable some of those features for more fine-grained control
+		// "strictNullChecks": true,
+		// "strictPropertyInitialization": true,
+		// "strictBindCallApply": true,
+		"noImplicitAny": false,
+		// "noUnusedLocals": true,
+		// "noUnusedParameters": true,
+
+		"target": "es2018",
+	},
+	"include": [
+		"lib/**/*.js",
+		"lib/**/*.d.ts",
+		"main.js"
+	]
+}


### PR DESCRIPTION
This PR adds `...Async` versions of the following methods to the script sandbox, so users can write promise-style scripts:
- setState
- setBinaryState
- getState
- getBinaryState
- existsState
- existsObject
- getObject
- setObject
- extendObject
- deleteObject
- createState
- deleteState
- writeFile
- readFile
- unlink
- delFile
- runScript
- startScript
- stopScript

In addition, it adds the `...Async` versions of these methods to the `$` selector result:

- getState
- getBinaryState
- setState
- setBinaryState

And it adds the methods `wait` and `sleep` (which are the same) to waiting in async code - `await wait(1000)` waits 1000ms before continuing.

fixes: #155 
fixes: #635