### PR TITLE
Match exact ID if $ selector contains no wildcard

### DIFF
--- a/lib/sandbox.js
+++ b/lib/sandbox.js
@@ -159,19 +159,14 @@ function sandBox(script, name, verbose, debug, context) {
      * @param {string} str The selector string to transform into a regular expression
      */
     function selectorStringToRegExp(str) {
-        if (str[0] === '*') {
-            // wildcard at the start, match the end of the string
-            return new RegExp(str.replace(/\./g, '\\.').replace(/\*/g, '.*') + '$');
-        } else if (str[str.length - 1] === '*') {
-            // wildcard at the end, match the start of the string
-            return new RegExp('^' + str.replace(/\./g, '\\.').replace(/\*/g, '.*'));
-        } else if (str.indexOf('*') > -1) {
-            // wildcard potentially in the middle, match whatever
-            return new RegExp(str.replace(/\./g, '\\.').replace(/\*/g, '.*'));
-        } else {
-            // no wildcard, match exact string (GH#652)
-            return new RegExp(`^${str.replace(/\./g, '\\.')}$`);
-        }
+        const startsWithWildcard = str[0] === '*';
+        const endsWithWildcard = str[str.length - 1] === '*';
+
+        return new RegExp(
+            (startsWithWildcard ? '' : '^')
+            + str.replace(/\./g, '\\.').replace(/\*/g, '.*')
+            + (endsWithWildcard ? '' : '$')
+        );
     }
 
     /**

--- a/lib/sandbox.js
+++ b/lib/sandbox.js
@@ -162,9 +162,15 @@ function sandBox(script, name, verbose, debug, context) {
         const startsWithWildcard = str[0] === '*';
         const endsWithWildcard = str[str.length - 1] === '*';
 
+        // Sanitize the selector so it is safe to use in a RegEx
+        // Taken from https://stackoverflow.com/a/3561711/10179833 but modified
+        // since * has a special meaning in our selector and should not be escaped
+        // eslint-disable-next-line no-useless-escape
+        str = str.replace(/[-\/\\^$+?.()|[\]{}]/g, '\\$&').replace(/\*/g, '.*');
+
         return new RegExp(
             (startsWithWildcard ? '' : '^')
-            + str.replace(/\./g, '\\.').replace(/\*/g, '.*')
+            + str
             + (endsWithWildcard ? '' : '$')
         );
     }

--- a/lib/sandbox.js
+++ b/lib/sandbox.js
@@ -165,9 +165,12 @@ function sandBox(script, name, verbose, debug, context) {
         } else if (str[str.length - 1] === '*') {
             // wildcard at the end, match the start of the string
             return new RegExp('^' + str.replace(/\./g, '\\.').replace(/\*/g, '.*'));
-        } else {
+        } else if (str.indexOf('*') > -1) {
             // wildcard potentially in the middle, match whatever
             return new RegExp(str.replace(/\./g, '\\.').replace(/\*/g, '.*'));
+        } else {
+            // no wildcard, match exact string (GH#652)
+            return new RegExp(`^${str.replace(/\./g, '\\.')}$`);
         }
     }
 


### PR DESCRIPTION
The current logic would not match a full string if the wildcard was neither at the start nor the end of the selector - which in turn implied that there was a wildcard at the start AND the end.

fixes: #652 
