### PR TITLE
Make query result iterable

### DIFF
--- a/lib/javascript.d.ts
+++ b/lib/javascript.d.ts
@@ -381,7 +381,7 @@ declare global {
 			oldFromNe?: string | string[] | RegExp;
 		}
 
-		interface QueryResult {
+		interface QueryResult extends Iterable<string> {
 			/** State-ID */
 			[index: number]: string;
 			/** Number of matched states */

--- a/lib/sandbox.js
+++ b/lib/sandbox.js
@@ -782,6 +782,12 @@ function sandBox(script, name, verbose, debug, context) {
                 result[i] = res[i];
             }
             result.length = res.length;
+            // Implementing the Symbol.iterator contract makes the query result iterable
+            result[Symbol.iterator] = function*() {
+                for (let i = 0; i < result.length; i++) {
+                    yield result[i];
+                }
+            };
             result.each = function (callback) {
                 if (typeof callback === 'function') {
                     let r;


### PR DESCRIPTION
fixes: #661 by implementing proposal 2

Sample code:
```js
const result = $('system.adapter.*.alive');
for (const val of result) {
    log(val);
}
const arr = [...result];
console.log(arr);
```

Log output:
```

javascript.0 | 2020-10-09 17:29:47.365 | info | (6844) script.js.Skript_1:  ['system.adapter.zwave2.0.alive','system.adapter.admin.0.alive','system.adapter.javascript.0.alive','system.adapter.web.0.alive']
javascript.0 | 2020-10-09 17:29:47.365 | info | (6844) script.js.Skript_1: system.adapter.web.0.alive
javascript.0 | 2020-10-09 17:29:47.365 | info | (6844) script.js.Skript_1: system.adapter.javascript.0.alive
javascript.0 | 2020-10-09 17:29:47.365 | info | (6844) script.js.Skript_1: system.adapter.admin.0.alive
javascript.0 | 2020-10-09 17:29:47.365 | info | (6844) script.js.Skript_1: system.adapter.zwave2.0.alive

```