### PR TITLE
hoist some more statements outside async function wrapper and ...

### DIFF
--- a/lib/typescriptTools.js
+++ b/lib/typescriptTools.js
@@ -143,10 +143,11 @@ function resolveTypings(pkg, wrapInDeclareModule) {
 
 /**
  * Takes a TypeScript script and does the necessary transformations so it can be compiled properly
- * @param {string} source
+ * @param {string} source The original TypeScript source
+ * @param {boolean} [forceModule] Whether the transformed file should be treated as a module by TypeScript. This should be false for global scripts
  * @returns {string}
  */
-function transformScriptBeforeCompilation(source) {
+function transformScriptBeforeCompilation(source, forceModule = true) {
     /**
      * @type {import("typescript").TransformerFactory<import("typescript").SourceFile>}
      */
@@ -187,25 +188,41 @@ function transformScriptBeforeCompilation(source) {
                     return ts.updateSourceFileNode(node, [
                         // Put the hoisted statements at the top (or all of them if there's no top level await)
                         ...hoistedStatements,
-                        ...(hasTLA ?
-                            // If there is a top-level await, wrap all non-hoisted statements in (async () => { ... })();
-                            [ts.createExpressionStatement(
-                                ts.createCall(
-                                    ts.createArrowFunction(
-                                        [ts.createModifier(ts.SyntaxKind.AsyncKeyword)],
+                        ...(hasTLA
+                            ? // If there is a top-level await, wrap all non-hoisted statements in (async () => { ... })();
+                            [
+                                ts.createExpressionStatement(
+                                    ts.createCall(
+                                        ts.createArrowFunction(
+                                            [
+                                                ts.createModifier(
+                                                    ts.SyntaxKind.AsyncKeyword
+                                                ),
+                                            ],
+                                            undefined,
+                                            [],
+                                            undefined,
+                                            undefined,
+                                            ts.createBlock(wrappedStatements)
+                                        ),
                                         undefined,
-                                        [],
-                                        undefined,
-                                        undefined,
-                                        ts.createBlock(wrappedStatements)
-                                    ),
+                                        undefined
+                                    )
+                                ),
+                            ]
+                            : []),
+                        ...(forceModule
+                            ? [
+                                // Put an empty export {}; at the bottom to force TypeScript to treat the script as a module
+                                ts.createExportDeclaration(
+                                    undefined,
+                                    undefined,
+                                    ts.createNamedExports([]),
                                     undefined,
                                     undefined
-                                )
-                            )]
+                                ),
+                            ]
                             : []),
-                        // Put an empty export {}; at the bottom to force TypeScript to treat the script as a module
-                        ts.createExportDeclaration(undefined, undefined, ts.createNamedExports([]), undefined, undefined),
                     ]);
                 } else {
                     return node;

--- a/lib/typescriptTools.js
+++ b/lib/typescriptTools.js
@@ -155,6 +155,8 @@ function transformScriptBeforeCompilation(source) {
         return (sourceFile) =>
             ts.visitNode(sourceFile, (node) => {
                 if (ts.isSourceFile(node)) {
+                    // If there is no top level await, don't move all the statements around
+                    const hasTLA = node.statements.some(s => ts.isExpressionStatement(s) && s.expression.kind === ts.SyntaxKind.AwaitExpression);
                     // Move all statements to the top of the file that cannot appear in a function body
                     /** @param {ts.Statement} s */
                     const mustBeHoisted = (s) => {
@@ -164,8 +166,14 @@ function transformScriptBeforeCompilation(source) {
                             ts.isImportEqualsDeclaration(s) ||
                             ts.isExportDeclaration(s) ||
                             ts.isExportAssignment(s) ||
-                            // declare class/interface/function/... statements too
-                            // as well as export const etc.
+                            // as well as many declarations
+                            ts.isTypeAliasDeclaration(s) ||
+                            ts.isInterfaceDeclaration(s) ||
+                            ts.isModuleDeclaration(s) ||
+                            ts.isEnumDeclaration(s) ||
+                            ts.isClassDeclaration(s) ||
+                            ts.isFunctionDeclaration(s) ||
+                            // and declare ... / export ... statements
                             (s.modifiers &&
                                 s.modifiers.some(
                                     (s) => s.kind === ts.SyntaxKind.DeclareKeyword
@@ -173,27 +181,29 @@ function transformScriptBeforeCompilation(source) {
                                 ))
                         );
                     };
-                    const hoistedStatements = node.statements.filter(mustBeHoisted);
-                    const otherStatements = node.statements.filter(s => !mustBeHoisted(s));
+                    const hoistedStatements = hasTLA ? node.statements.filter(mustBeHoisted) : node.statements;
+                    const wrappedStatements = hasTLA ? node.statements.filter(s => !mustBeHoisted(s)) : [];
 
                     return ts.updateSourceFileNode(node, [
-                        // Put the import statements at the top
+                        // Put the hoisted statements at the top (or all of them if there's no top level await)
                         ...hoistedStatements,
-                        // Wrap all other statements in (async () => { ... })();
-                        ts.createExpressionStatement(
-                            ts.createCall(
-                                ts.createArrowFunction(
-                                    [ts.createModifier(ts.SyntaxKind.AsyncKeyword)],
+                        ...(hasTLA ?
+                            // If there is a top-level await, wrap all non-hoisted statements in (async () => { ... })();
+                            [ts.createExpressionStatement(
+                                ts.createCall(
+                                    ts.createArrowFunction(
+                                        [ts.createModifier(ts.SyntaxKind.AsyncKeyword)],
+                                        undefined,
+                                        [],
+                                        undefined,
+                                        undefined,
+                                        ts.createBlock(wrappedStatements)
+                                    ),
                                     undefined,
-                                    [],
-                                    undefined,
-                                    undefined,
-                                    ts.createBlock(otherStatements)
-                                ),
-                                undefined,
-                                undefined
-                            )
-                        ),
+                                    undefined
+                                )
+                            )]
+                            : []),
                         // Put an empty export {}; at the bottom to force TypeScript to treat the script as a module
                         ts.createExportDeclaration(undefined, undefined, ts.createNamedExports([]), undefined, undefined),
                     ]);

--- a/main.js
+++ b/main.js
@@ -192,10 +192,10 @@ function loadTypeScriptDeclarations() {
 
 /**
  * @param {string} source The original TypeScript source
- * @param {boolean} [forceModule] Whether the transformed file should be treated as a module by TypeScript. This should be false for global scripts
+ * @param {boolean} [forceModule] Whether the transformed file should be treated as a module by TypeScript. This should be false for global scripts and true for "normal" scripts
  * @returns {string}
  */
-function transformTSScript(source, forceModule = false) {
+function transformTSScript(source, forceModule = true) {
     try {
         // Try to execute the smart transformer script
         return transformScriptBeforeCompilation(source, forceModule);

--- a/test/testTypeScript.js
+++ b/test/testTypeScript.js
@@ -18,7 +18,7 @@ describe('TypeScript tools', () => {
             expect(transformed).to.include(expected);
         });
 
-        it('but only if it is really necessary', () => {
+        it('...but only if it is really necessary', () => {
             const source = `log("test")`;
             const expected = `log("test");\nexport {};\n`.replace(/\n/g, require('os').EOL);
             const transformed = transformScriptBeforeCompilation(source);
@@ -30,6 +30,13 @@ describe('TypeScript tools', () => {
             const expected = /^export \{\};$/m;
             const transformed = transformScriptBeforeCompilation(source);
             expect(transformed).to.match(expected);
+        });
+
+        it('...but only if the file should be treated as a module', () => {
+            const source = `foo;`;
+            const expected = /^export \{\};$/m;
+            const transformed = transformScriptBeforeCompilation(source, false);
+            expect(transformed).not.to.match(expected);
         });
     });
 

--- a/test/testTypeScript.js
+++ b/test/testTypeScript.js
@@ -18,6 +18,13 @@ describe('TypeScript tools', () => {
             expect(transformed).to.include(expected);
         });
 
+        it('but only if it is really necessary', () => {
+            const source = `log("test")`;
+            const expected = `log("test");\nexport {};\n`.replace(/\n/g, require('os').EOL);
+            const transformed = transformScriptBeforeCompilation(source);
+            expect(transformed).to.equal(expected);
+        });
+
         it('appends an empty export statement', () => {
             const source = `foo;`;
             const expected = /^export \{\};$/m;
@@ -52,13 +59,23 @@ describe('TypeScript compilation regression tests', () => {
 import * as fs from "fs";
 await wait(100);
 `,
-        // declare any statement with `declare` must be hoisted
+        // any statement with `declare` must be hoisted
+        // as well as export statements
+        // and type/interface/namespace/enum declarations
         `
 declare function test(): any;
 declare class Test {};
 declare interface Foo {};
 export const bla = 1;
 export { test };
+type Foo2 = 1;
+interface Foo3 {
+    member: any;
+}
+namespace whatever {}
+enum Bar {
+    baz = 1,
+}
         `,
         // Simplified repro from #677
         `
@@ -69,7 +86,6 @@ class Foo {
     }
 }
 `
-
     ];
 
     for (let i = 0; i < tests.length; i++) {


### PR DESCRIPTION
...only wrap if there is a top level await.

With this PR, the TLA-wrapping only occurs if there is an `await` statement at the top level of a script. This means that simple scripts are no longer wrapped with an unnecessary async function:
```ts
log("1")
```
is now transformed to
```
log("1");
export {};
```

Furthermore, more statements that must be outside the async function are hoisted, including:
* `type`
* `interface`
* `namespace`
* `enum`
* `class`
* `function` (but not const arrow functions)