### PR TITLE
add exnext dependency / fix esnext.asynciterable missing compile error

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,4 +1,5 @@
 {
+        "lib": ["es6", "dom", "esnext.asynciterable"],
 	"compileOnSave": true,
 	"compilerOptions": {
 		// do not compile anything, this file is just to configure type checking


### PR DESCRIPTION
After updating from 4.8.4 to 4.9.4 I had many compile errors like this:

(async () => { class Switch {
^
ERROR: File 'lib.esnext.bigint.d.ts' not found.

Adding the esnext dependancy to tsconfig.json fixes the issue.