### PR TITLE
Enable downlevelIteration to support iterable query results in TypeScript

### DIFF
--- a/lib/typescriptSettings.js
+++ b/lib/typescriptSettings.js
@@ -18,6 +18,8 @@ const tsCompilerOptions = {
     // scripts may include `import` keywords, which are not
     // supported by vm.Script.
     target: typescript.ScriptTarget.ES5,
+    // This is required for QueryResults to be iterable (https://github.com/ioBroker/ioBroker.javascript/pull/663#issuecomment-721645705)
+    downlevelIteration: true,
     lib: [`lib.${targetTsLib}.d.ts`],
 };
 

--- a/test/testTypeScript.js
+++ b/test/testTypeScript.js
@@ -92,6 +92,11 @@ class Foo {
         this.prop = true;
     }
 }
+`,
+        // Repro for https://github.com/ioBroker/ioBroker.javascript/pull/663#issuecomment-721645705
+        `
+const result = $('system.adapter.*.alive');
+const arr = [...result];
 `
     ];
 


### PR DESCRIPTION
Seems like I missed this in #663 