### PR TITLE
Async-wrap classes and functions in non-global scripts

### DIFF
--- a/lib/typescriptTools.js
+++ b/lib/typescriptTools.js
@@ -141,8 +141,11 @@ function resolveTypings(pkg, wrapInDeclareModule) {
     return ret;
 }
 
-/** @param {import("typescript").Statement} s */
-function mustBeHoisted(s) {
+/**
+ * @param {import("typescript").Statement} s
+ * @param {boolean} isGlobal Whether this is a global script or a normal one
+ */
+function mustBeHoisted(s, isGlobal) {
     return (
         // Import/export statements must be moved to the top
         ts.isImportDeclaration(s) ||
@@ -154,8 +157,11 @@ function mustBeHoisted(s) {
         ts.isInterfaceDeclaration(s) ||
         ts.isModuleDeclaration(s) ||
         ts.isEnumDeclaration(s) ||
-        ts.isClassDeclaration(s) ||
-        ts.isFunctionDeclaration(s) ||
+        (isGlobal && (
+            // in global scripts we don't wrap classes and functions so they can be accessed from non-global scripts
+            ts.isClassDeclaration(s) ||
+            ts.isFunctionDeclaration(s)
+        )) ||
         // and declare ... / export ... statements
         (s.modifiers &&
             s.modifiers.some(
@@ -257,8 +263,8 @@ function transformScriptBeforeCompilation(source, isGlobal) {
                     // If there is no top level await, don't move all the statements around
                     const hasTLA = node.statements.some(s => ts.isExpressionStatement(s) && s.expression.kind === ts.SyntaxKind.AwaitExpression);
                     // Move all statements to the top of the file that cannot appear in a function body
-                    let hoistedStatements = hasTLA ? ts.createNodeArray(node.statements.filter(mustBeHoisted)) : node.statements;
-                    const wrappedStatements = hasTLA ? node.statements.filter(s => !mustBeHoisted(s)) : [];
+                    let hoistedStatements = hasTLA ? ts.createNodeArray(node.statements.filter((s) => mustBeHoisted(s, isGlobal))) : node.statements;
+                    const wrappedStatements = hasTLA ? node.statements.filter(s => !mustBeHoisted(s, isGlobal)) : [];
 
                     // When transforming global scripts, we need to do two things
                     if (isGlobal) {

--- a/test/testTypeScript.js
+++ b/test/testTypeScript.js
@@ -154,6 +154,16 @@ class Foo {
         `
 const result = $('system.adapter.*.alive');
 const arr = [...result];
+`,
+        // Repro from #705
+        `
+const foo = 42;
+
+async function bar():Promise<void> {
+    return new Promise<void>(() => log(foo.toString()));
+}
+
+await bar();
 `
     ];
 


### PR DESCRIPTION
fixes: #705 

With top-level-await (TLA), we need to make some compromises. If using TLA in global scripts, we cannot wrap classes and functions in `(async () => {...})()` or they cannot be used from non-global scripts. As a result, we cannot access the scope outside the functions because that is now in the async wrapper. For example:

```ts
const foo = 42;
function bar():Promise<void> {
    return new Promise<void>(() => log(foo.toString()));
}
await bar();
```
becomes
```ts
async function bar(): Promise<void> {
    return new Promise<void>(() => log(foo.toString()));
}
(async () => {
    const foo = 42;
    await bar();
})();
export {};
```
after the transformation. `function bar` is still accessible from non-global scripts, but that function loses access to `foo`. We could reorder the statements to fix this, but that will just cause us to go further down the magic rabbit hole.

As a compromise we could disallow TLA in global scripts - or (like this PR does) no longer move functions outside the async wrapper in non-global scripts.
The above script would still be broken as a global script, but now works if used as a non-global script.