### PR TITLE
Filter out "" from the adapter libraries

### DIFF
--- a/main.js
+++ b/main.js
@@ -158,8 +158,8 @@ function loadTypeScriptDeclarations() {
         && typeof adapter.config.libraries === 'string'
         && typeof adapter.config.libraryTypings === 'string'
     ) {
-        const installedLibs = adapter.config.libraries.split(/[,;\s]+/).map(s => s.trim());
-        const wantsTypings = adapter.config.libraryTypings.split(/[,;\s]+/).map(s => s.trim());
+        const installedLibs = adapter.config.libraries.split(/[,;\s]+/).map(s => s.trim()).filter(s => !!s);
+        const wantsTypings = adapter.config.libraryTypings.split(/[,;\s]+/).map(s => s.trim()).filter(s => !!s);
         // Add all installed libraries the user has requested typings for to the list of packages
         for (const lib of installedLibs) {
             if (


### PR DESCRIPTION
Fixes an adapter crash that only happens during testing. The adapter tests have an empty string for the adapter config which was interpreted as a node module.

With ee955b1060e3458ad9920889d4124d64cd4c7d8b, this started breaking the tests. This PR fixes it.