### PR TITLE
fix: don't change require path, don't use hand-rolled fallback

### DIFF
--- a/lib/sandbox.js
+++ b/lib/sandbox.js
@@ -409,16 +409,11 @@ function sandBox(script, name, verbose, debug, context) {
                 return mods[md];
             } else {
                 try {
-                    mods[md] = require(`${__dirname}/../node_modules/${md}`);
+                    mods[md] = require(md);
                     return mods[md];
                 } catch (e) {
-                    try {
-                        mods[md] = require(`${__dirname}/../../${md}`);
-                        return mods[md];
-                    } catch (e) {
-                        adapter.setState('scriptProblem.' + name.substring('script.js.'.length), true, true);
-                        context.logError(name, e, 6);
-                    }
+                    adapter.setState('scriptProblem.' + name.substring('script.js.'.length), true, true);
+                    context.logError(name, e, 6);
                 }
             }
         },


### PR DESCRIPTION
The current `require` implementation in the sandbox masks errors when a module exists but cannot be loaded. This happens when the module to load uses ESM instead of CommonJS, like `firebase@9` and `p-limit@4` do. Instead of `cannot find module /some/weird/path`, these now get a correct error message:
```
Error [ERR_REQUIRE_ESM]: require() of ES Module [...]/p-limit/index.js from [...] not supported.
```

fixes: #893
avoids confusion like the one in #892