### PR TITLE
When mirroring, monitor symlinked files separately from directories

### DIFF
--- a/lib/mirror.js
+++ b/lib/mirror.js
@@ -75,11 +75,15 @@ class Mirror {
                         return;
                     }
 
-                    this.log.info("Watch symlink " + name);
-                    fs.watch(fs.readlinkSync(name), (eventType, _filename) => {
-                        // Pretend the symlink source was changed.
-                        this.log.debug("File " + name + " " + eventType);
-                        this.onFileChange(eventType, name);
+                    const linkTarget = fs.realpathSync(name);
+
+                    this.log.info(
+                      "Watch symlinked file " + name + " -> " + linkTarget
+                    );
+                    fs.watch(linkTarget, (eventType, _filename) => {
+                      // Pretend the symlink source was changed.
+                      this.log.debug("File " + name + " " + eventType);
+                      this.onFileChange(eventType, name);
                     });
                 }
             });

--- a/lib/mirror.js
+++ b/lib/mirror.js
@@ -65,7 +65,23 @@ class Mirror {
             files.forEach(file => {
                 const name = path.join(root_, file).replace(/\\/g, '/');
                 const stat = fs.statSync(name);
-                stat.isDirectory() && this.watchFolders(name);
+
+                if (stat.isDirectory()) {
+                    this.watchFolders(name);
+                }
+                else {
+                    const lstat = fs.lstatSync(name);
+                    if (!lstat.isSymbolicLink()) {
+                        return;
+                    }
+
+                    this.log.info("Watch symlink " + name);
+                    fs.watch(fs.readlinkSync(name), (eventType, _filename) => {
+                        // Pretend the symlink source was changed.
+                        this.log.debug("File " + name + " " + eventType);
+                        this.onFileChange(eventType, name);
+                    });
+                }
             });
         } catch (err) {
             this.log.warn(`Error while trying to watch folder ${root_}: ${err}`);

--- a/test/testMirror.js
+++ b/test/testMirror.js
@@ -46,7 +46,7 @@ describe("Mirror", () => {
         const script = path.join(unwatched, "script.js");
         fs.closeSync(fs.openSync(script, "w"));
 
-        // ..but symlinked as a file from a watched directory.
+        // ...but symlinked as a file from a watched directory.
         const symlink = path.join(watched, "symlinked-script.js");
         fs.symlinkSync(script, symlink);
 
@@ -68,9 +68,76 @@ describe("Mirror", () => {
         const script = path.join(unwatched, "script.js");
         fs.closeSync(fs.openSync(script, "w"));
 
-        // ..but symlinked as a directory from a watched directory.
+        // ...but symlinked as a directory from a watched directory.
         const symlink = path.join(watched, "symlinked-directory");
         fs.symlinkSync(unwatched, symlink, "dir");
+
+        mirror.onFileChange = (event, file) => {
+          if (process.platform === "linux" || process.platform === "win32") {
+            expect(path.normalize(file)).to.equal(path.join(symlink, path.basename(script)));
+
+            done();
+          }
+
+          if (process.platform === "darwin") {
+            if (
+              event === "rename" &&
+              file === path.join(symlink, path.basename(script))
+            ) {
+              done();
+            }
+          }
+        };
+
+        mirror.watchFolders(watched);
+
+        fs.appendFileSync(script, "some code");
+      });
+
+      it("notifies about changes to relatively symlinked files", (done) => {
+        // Script is located in an unwatched directory...
+        const unwatched = fs.mkdtempSync(
+          path.join(os.tmpdir(), "mirror-test-unwatched-")
+        );
+
+        const script = path.join(unwatched, "script.js");
+        fs.closeSync(fs.openSync(script, "w"));
+
+        // ...but symlinked as a file from a watched directory.
+        const symlink = path.join(watched, "symlinked-script.js");
+        const relativeDirectory = path.relative(
+          path.dirname(symlink),
+          path.dirname(script)
+        );
+
+        fs.symlinkSync(
+          path.join(relativeDirectory, path.basename(script)),
+          symlink
+        );
+
+        mirror.onFileChange = (_event, file) => {
+          expect(path.normalize(file)).to.equal(symlink);
+
+          done();
+        };
+
+        mirror.watchFolders(watched);
+
+        fs.appendFileSync(script, "some code");
+      });
+
+      it("notifies about changes to relatively symlinked directories", (done) => {
+        // Script is located in an unwatched directory...
+        const unwatched = fs.mkdtempSync(path.join(os.tmpdir(), "mirror-test-unwatched-"));
+
+        const script = path.join(unwatched, "script.js");
+        fs.closeSync(fs.openSync(script, "w"));
+
+        // ...but symlinked as a directory from a watched directory.
+        const symlink = path.join(watched, "symlinked-directory");
+        const relativeSymlink = path.relative(watched, unwatched);
+
+        fs.symlinkSync(relativeSymlink, symlink, "dir");
 
         mirror.onFileChange = (event, file) => {
           if (process.platform === "linux" || process.platform === "win32") {

--- a/test/testMirror.js
+++ b/test/testMirror.js
@@ -72,10 +72,21 @@ describe("Mirror", () => {
         const symlink = path.join(watched, "symlinked-directory");
         fs.symlinkSync(unwatched, symlink, "dir");
 
-        mirror.onFileChange = (_event, file) => {
-          expect(file).to.equal(path.join(symlink, path.basename(script)));
+        mirror.onFileChange = (event, file) => {
+          if (process.platform === 'linux') {
+            expect(file).to.equal(path.join(symlink, path.basename(script)));
 
-          done();
+            done();
+          }
+
+          if (process.platform === 'darwin') {
+            if (
+              event === "rename" &&
+              file === path.join(symlink, path.basename(script))
+            ) {
+              done();
+            }
+          }
         };
 
         mirror.watchFolders(watched);

--- a/test/testMirror.js
+++ b/test/testMirror.js
@@ -1,0 +1,87 @@
+const expect = require("chai").expect;
+const os = require("os");
+const path = require("path");
+const fs = require("fs");
+const Mirror = require("../lib/mirror");
+
+describe("Mirror", () => {
+  describe("File system watcher", () => {
+    let mirror = null;
+    let watched = null;
+
+    beforeEach(() => {
+      watched = fs.mkdtempSync(path.join(os.tmpdir(), "mirror-test-watched-"));
+
+      const noop = () => {};
+
+      mirror = new Mirror({
+        diskRoot: watched,
+        adapter: {
+          namespace: "javascript.0",
+          getForeignObject: noop,
+        },
+      });
+    });
+
+    describe("watchFolders", () => {
+      it("notifies about changes to normal files", (done) => {
+        const script = path.join(watched, "script.js");
+        fs.closeSync(fs.openSync(script, "w"));
+
+        mirror.onFileChange = (_event, file) => {
+          expect(file).to.equal(script);
+
+          done();
+        };
+
+        mirror.watchFolders(watched);
+
+        fs.appendFileSync(script, "some code");
+      });
+
+      it("notifies about changes to symlinked files", (done) => {
+        // Script is located in an unwatched directory...
+        const unwatched = fs.mkdtempSync(path.join(os.tmpdir(), "mirror-test-unwatched-"));
+
+        const script = path.join(unwatched, "script.js");
+        fs.closeSync(fs.openSync(script, "w"));
+
+        // ..but symlinked as a file from a watched directory.
+        const symlink = path.join(watched, "symlinked-script.js");
+        fs.symlinkSync(script, symlink);
+
+        mirror.onFileChange = (_event, file) => {
+          expect(file).to.equal(symlink);
+
+          done();
+        };
+
+        mirror.watchFolders(watched);
+
+        fs.appendFileSync(script, "some code");
+      });
+
+      it("notifies about changes to symlinked directories", (done) => {
+        // Script is located in an unwatched directory...
+        const unwatched = fs.mkdtempSync(path.join(os.tmpdir(), "mirror-test-unwatched-"));
+
+        const script = path.join(unwatched, "script.js");
+        fs.closeSync(fs.openSync(script, "w"));
+
+        // ..but symlinked as a directory from a watched directory.
+        const symlink = path.join(watched, "symlinked-directory");
+        fs.symlinkSync(unwatched, symlink, "dir");
+
+        mirror.onFileChange = (_event, file) => {
+          expect(file).to.equal(path.join(symlink, path.basename(script)));
+
+          done();
+        };
+
+        mirror.watchFolders(watched);
+
+        fs.appendFileSync(script, "some code");
+      });
+    });
+  });
+});

--- a/test/testMirror.js
+++ b/test/testMirror.js
@@ -29,7 +29,7 @@ describe("Mirror", () => {
         fs.closeSync(fs.openSync(script, "w"));
 
         mirror.onFileChange = (_event, file) => {
-          expect(file).to.equal(script);
+          expect(path.normalize(file)).to.equal(script);
 
           done();
         };
@@ -51,7 +51,7 @@ describe("Mirror", () => {
         fs.symlinkSync(script, symlink);
 
         mirror.onFileChange = (_event, file) => {
-          expect(file).to.equal(symlink);
+          expect(path.normalize(file)).to.equal(symlink);
 
           done();
         };
@@ -73,13 +73,13 @@ describe("Mirror", () => {
         fs.symlinkSync(unwatched, symlink, "dir");
 
         mirror.onFileChange = (event, file) => {
-          if (process.platform === 'linux') {
-            expect(file).to.equal(path.join(symlink, path.basename(script)));
+          if (process.platform === "linux" || process.platform === "win32") {
+            expect(path.normalize(file)).to.equal(path.join(symlink, path.basename(script)));
 
             done();
           }
 
-          if (process.platform === 'darwin') {
+          if (process.platform === "darwin") {
             if (
               event === "rename" &&
               file === path.join(symlink, path.basename(script))


### PR DESCRIPTION
Hello,

this PR might be a bit unusual, but let me explain.

I run ioBroker at two sites, "home" and "ogd". Both sites share some of my scripts and all of my `globals` library code. Both sites use script mirroring because I prefer to edit code with VS Code and use git to maintain the source. I have the two "site" directories, where the "ogd" site may reuse stuff from "home". To reuse scripts, I create symlinks where e.g. `ogd/script.ts` is a symlink to `../home/script.ts` which makes the script available on both sites.

The problem this PR attempts to solve arises when I e.g. edit the `home/script.ts` file. The "ogd" site's mirroring feature only watches the "ogd" subdirectory of my source tree, e.g. the directory where the symlink resides. Edits to `home/script.ts` do not change the symlink, but rather the symlink target and hence do not get picked up by the file system watcher.

This PR is a draft that attempts to fix this. Instead of watching directories, it adds special handling for symlinked files. If such files are encountered a new `fs.watch()` call is issued for the symlink *target*. But when those specific watchers emit an event we pretend the symlink itself was updated.

Here's an example of a directory with symlinked files: https://github.com/agross/iobroker-scripts/tree/7a75cb4f4b6e7ddb8b2e918db3172fc8c7f80b40/ogd/Automation/Oneshot

The second test case (`notifies about changes to symlinked files`) is the one that fails without the new code in `mirror.js`.

Please let me know what you think. 