### PR TITLE
fix astro schedules

### DIFF
--- a/lib/javascript.d.ts
+++ b/lib/javascript.d.ts
@@ -1356,7 +1356,7 @@ declare global {
 	 * @param date (optional) The date for which the astro time should be calculated. Default = today
 	 * @param offsetMinutes (optional) The amount of minutes to be added to the return value.
 	 */
-	function getAstroDate(pattern: string, date?: number, offsetMinutes?: number): Date;
+	function getAstroDate(pattern: string, date?: Date | number, offsetMinutes?: number): Date;
 
 	/**
 	 * Determines if now is between sunrise and sunset.

--- a/lib/sandbox.js
+++ b/lib/sandbox.js
@@ -1224,7 +1224,16 @@ function sandBox(script, name, verbose, debug, context) {
                     return;
                 }
 
-                let ts = mods.suncalc.getTimes(nowdate, adapter.config.latitude, adapter.config.longitude)[pattern.astro];
+                //ensure events are calculated independent of current time
+                let todayNoon = new Date(nowdate);
+                todayNoon.setHours(12, 0, 0, 0);
+                let ts = mods.suncalc.getTimes(todayNoon, adapter.config.latitude, adapter.config.longitude)[pattern.astro];
+
+                //event on next day, correct or force recalculation at midnight
+                if (todayNoon.getDate() !== ts.getDate()) {
+                    todayNoon.setDate(todayNoon.getDate() - 1);
+                    ts = mods.suncalc.getTimes(todayNoon, adapter.config.latitude, adapter.config.longitude)[pattern.astro];
+                }
 
                 if (ts.getTime().toString() === 'NaN') {
                     adapter.log.warn('Cannot calculate "' + pattern.astro + '" for ' + adapter.config.latitude + ', ' + adapter.config.longitude);
@@ -1252,13 +1261,12 @@ function sandBox(script, name, verbose, debug, context) {
                 if (!ts || ts < nowdate) {
                     const date = new Date(nowdate);
                     // Event doesn't occur today - try again tomorrow
-                    // Calculate time till 24:00 and set timeout
+                    // Calculate time till 24:00 (local, NOT UTC) and set timeout
                     date.setDate(date.getDate() + 1);
-                    date.setMinutes(1); // Sometimes timer fires at 23:59:59
+                    date.setMinutes(0); // Sometimes timer fires at 23:59:59
                     date.setHours(0);
-                    date.setSeconds(0);
+                    date.setSeconds(1);
                     date.setMilliseconds(0);
-                    date.setMinutes(-date.getTimezoneOffset());
 
                     // Calculate new schedule in the next day
                     sandbox.setTimeout(() => {
@@ -1349,14 +1357,9 @@ function sandBox(script, name, verbose, debug, context) {
                 return;
             }
 
+            //ensure events are calculated independent of current time
+            date.setHours(12, 0, 0, 0);
             let ts = mods.suncalc.getTimes(date, adapter.config.latitude, adapter.config.longitude)[pattern];
-            const nadir = mods.suncalc.getTimes(date, adapter.config.latitude, adapter.config.longitude)['nadir'];
-            if (nadir.getDate() === date.getDate() && nadir.getHours() < 12) {
-                ts = mods.suncalc.getTimes(date.setDate(date.getDate() + 1), adapter.config.latitude, adapter.config.longitude)[pattern];
-            }
-            if (nadir.getDate() !== date.getDate() && nadir.getHours() > 12) {
-                ts = mods.suncalc.getTimes(date.setDate(date.getDate() - 1), adapter.config.latitude, adapter.config.longitude)[pattern];
-            }
 
             if (ts === undefined || ts.getTime().toString() === 'NaN') {
                 adapter.log.error('Cannot get astro date for "' + pattern + '"');


### PR DESCRIPTION
- fix wrong calculation after midnight when UTC is still on old date. Events get rescheduled to the next day then, thus never get executed(valid for time zones behind of UTC, e.g. GMT+1, GMT+2 etc)

- fix wrong determination of 'next day' for time zones ahead of UTC, e.g. UTC-1,UTC-5 etc). Leaded to negative timeouts which caused endless loops at midnight UTC

- added Date as a valid parameter to getAstroDate()
- make getAstroDate() independent of the time it is invoked