### PR TITLE
Fix module name extraction

### DIFF
--- a/main.js
+++ b/main.js
@@ -1428,7 +1428,11 @@ function installLibraries(callback) {
         for (let lib = 0; lib < libraries.length; lib++) {
             if (libraries[lib] && libraries[lib].trim()) {
                 libraries[lib] = libraries[lib].trim();
-                const libName = libraries[lib].split('@')[0];
+                let libName = libraries[lib];
+                let versionChunkPos = libName.indexOf('@', 1);
+                if (versionChunkPos > -1) {
+                    libName = libName.slice(0, versionChunkPos);
+                }
                 if (!nodeFS.existsSync(__dirname + '/node_modules/' + libName + '/package.json')) {
 
                     if (!attempts[libraries[lib]]) {


### PR DESCRIPTION
When having packages which name is having an organization or namespace like `@myorg/mypackage`, the name of the package is not extracted correctly so the install script will not find the module directory and shows an error that the package was not installed.