### PR TITLE
fix: downgrade TypeScript to 4.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   },
   "dependencies": {
     "@iobroker/adapter-core": "^2.6.0",
-    "@types/node": "^18.6.3",
+    "@types/node": "^16.11.56",
     "@types/request": "^2.48.8",
     "coffeescript": "^1.12.7",
     "jsonata": "^1.8.6",
@@ -40,7 +40,7 @@
     "request": "^2.88.2",
     "semver": "^7.3.7",
     "suncalc2": "^1.8.1",
-    "typescript": "^4.7.4",
+    "typescript": "~4.7.4",
     "virtual-tsc": "^0.6.2",
     "wake_on_lan": "^1.0.0"
   },

--- a/test/testTypeScript.js
+++ b/test/testTypeScript.js
@@ -258,11 +258,17 @@ Date.prototype.getWeekYear = function () {
 
 const d = new Date();
 d.getWeekYear()
+`,
+        // Repro from #1106
+        `
+function test(): void {
+    log("test global");
+}
 `
     ];
 
     for (let i = 0; i < tests.length; i++) {
-    // for (const i of [1]) {
+        // for (const i of [1]) {
         it(`Test #${i + 1}`, () => {
             const transformedSource = transformScriptBeforeCompilation(tests[i], true);
             const filename = scriptIdToTSFilename(`script.js.test_${i + 1}`);


### PR DESCRIPTION
fixes: #1106

4.8 seems to have some breaking changes in the transformer magic we do for global TS scripts. I'll need to investigate, but IMO there's no need to support 4.8 right now.