### PR TITLE
Check Date value before execution of checkSchedules to make sure the time is really reached

### DIFF
--- a/lib/scheduler.js
+++ b/lib/scheduler.js
@@ -54,10 +54,10 @@ class Scheduler {
         const count = Object.keys(this.list).length;
         if (count && !this.timer) {
             const d = new this.Date();
-            d.setMilliseconds(0);
+            d.setMilliseconds(2); // 2 ms to be sure that the next second is reached, they do not hurt anyone
             d.setSeconds(0);
             d.setMinutes(d.getMinutes() + 1);
-            this.timer = setTimeout(() => this.checkSchedules(), d.getTime() - this.Date.now());
+            this.timer = setTimeout((notBefore) => this.checkSchedules(notBefore), d.getTime() - this.Date.now(), d.getTime());
         } else if (!count && this.timer) {
             clearTimeout(this.timer);
             this.timer = null;
@@ -78,8 +78,15 @@ class Scheduler {
         };
     }
 
-    checkSchedules() {
+    checkSchedules(notBeforeTime) {
         const context = this.getContext();
+
+        // Work around for not that precise RTCs in some system
+        if (notBeforeTime !== undefined && context.now < notBeforeTime) {
+            this.timer = setTimeout((notBefore) =>
+                this.checkSchedules(notBefore), notBeforeTime - this.Date.now(), notBeforeTime);
+            return;
+        }
 
         for (const id in this.list) {
             if (!this.list.hasOwnProperty(id)) {
@@ -91,11 +98,11 @@ class Scheduler {
         }
 
         const d = new this.Date();
-        d.setMilliseconds(0);
+        d.setMilliseconds(2); // 2 ms to be sure that the next second is reached, they do not hurt anyone
         d.setSeconds(0);
         d.setMinutes(d.getMinutes() + 1);
-        this.timer = setTimeout(() =>
-            this.checkSchedules(), d.getTime() - this.Date.now());
+        this.timer = setTimeout((notBefore) =>
+            this.checkSchedules(notBefore), d.getTime() - this.Date.now(), d.getTime());
     }
 
     monthDiff(d1, d2) {
@@ -175,7 +182,7 @@ class Scheduler {
         if (schedule.time) {
             let start = schedule.time.start;
             let end = schedule.time.end;
-            const now = new this.Date();
+            const now = new this.Date(context.now);
             const astroNameStart = this._getAstroName(start);
             const astroNameEnd = this._getAstroName(end);
 


### PR DESCRIPTION
(and add 2ms of unaccuracy to hopefully always be right without a retrigger)

And use "context.now" when checking schedules and not a new now for each call, so make sure it is the same timepoint for all checks.

fixes #1196