### PR TITLE
There is an implementation `setStateChanged`/`setStateChangedAsync` based on `adapter.setForeignStateChanged`.

### DIFF
--- a/docs/en/javascript.md
+++ b/docs/en/javascript.md
@@ -790,6 +790,18 @@ setStateDelayed('Kitchen.Light.Lamp', false, 5000, false, () => {
 ```
 This function returns the handler of the timer, and this timer can be individually stopped by clearStateDelayed
 
+### setStateChanged
+```js
+await setStateChanged(id, state, ack);
+```
+Same as setState, but set value only if the value is really changed.
+
+### setStateChangedAsync
+```js
+await setStateChangedAsync(id, state, ack);
+```
+Same as setStateChanged, but with `promise`.
+
 ### clearStateDelayed
 ```js
 clearStateDelayed(id);
@@ -954,9 +966,9 @@ extendObject('system.adapter.sayit.0', {common: {enabled: false}});
 deleteObject(id, isRecursive, callback);
 ```
 
-Delete an object from DB by ID. If the object has type `state`, the state value will be deleted too. 
+Delete an object from DB by ID. If the object has type `state`, the state value will be deleted too.
 
-Additional parameter `isRecursive` could be provided, so all children of given ID will be deleted. Very dangerous! 
+Additional parameter `isRecursive` could be provided, so all children of given ID will be deleted. Very dangerous!
 
 Use it like this:
 ```js
@@ -964,7 +976,7 @@ Use it like this:
 deleteObject('javascript.0.createdState');
 ```
 
-*Notice: `isRecursive` option is available only with js-controller >= 2.2.x* 
+*Notice: `isRecursive` option is available only with js-controller >= 2.2.x*
 
 ### getIdByName
 ```js
@@ -1016,10 +1028,10 @@ Create state and object in javascript space if it does not exist, e.g. `javascri
 - `native`: native description of an object. Any specific information.
 - `callback`: called after state is created and initialized.
 
-If you set in `common` the flag `alias` to `true`, then alias will be created with the same name (but in `alias.0` namespace) as the state. 
-Alias is created only if it does not exist yet. 
+If you set in `common` the flag `alias` to `true`, then alias will be created with the same name (but in `alias.0` namespace) as the state.
+Alias is created only if it does not exist yet.
 
-The following settings for aliases are valid too: 
+The following settings for aliases are valid too:
 ```js
 common => {
     alias: {
@@ -1481,16 +1493,16 @@ The alternative name of this method is `rename`
 ### onFile
 ```js
 onFile(id, fileName, withFile, (id, fileName, size, fileData, mimeType) => {});
-// or 
+// or
 onFile(id, fileName, (id, fileName, size) => {});
 ```
 
 Subscribe to file changes:
-- `id` is ID of an object of type `meta`, like `vis.0` 
+- `id` is ID of an object of type `meta`, like `vis.0`
 - `fileName` is file name or pattern, like `main/*` or `main/vis-view.json`
 - `withFile` if the content of file should be delivered in callback or not. the delivery of file content costs memory and time, so if you want to be just informed about changes, set `withFile`to false.
 
-Arguments in callback: 
+Arguments in callback:
 - `id` - ID of `meta` object;
 - `fileName` - file name (not pattern);
 - `size` - new file size;
@@ -1502,7 +1514,7 @@ Arguments in callback:
 ### offFile
 ```js
 offFile(id, fileName);
-// or 
+// or
 onFile(id, fileName);
 ```
 Unsubscribe from file changes:
@@ -1760,8 +1772,8 @@ To send a message from any other adapter use
 
 ```js
 adapter.sendTo('javascript.0', 'toScript', {
-    script: 'script.js.messagetest', 
-    message: 'messageName', 
+    script: 'script.js.messagetest',
+    message: 'messageName',
     data: {
         flag: true
     }
@@ -1916,7 +1928,7 @@ httpPost(
 log('Script ' + scriptName + ' started!');
 ```
 
-It is not a function. 
+It is not a function.
 It is a variable with script name, that is visible in script's scope.
 
 ### instance

--- a/docs/en/javascript.md
+++ b/docs/en/javascript.md
@@ -1925,17 +1925,33 @@ httpPost(
 `scriptName` - The name of the script.
 
 ```js
-log('Script ' + scriptName + ' started!');
+log(`Script ${scriptName} started!`);
 ```
 
-It is not a function.
-It is a variable with script name, that is visible in script's scope.
-
 ### instance
-The javascript instance where script is executed.
+`instance` - The javascript instance where script is executed (e.g. `0`).
 
 ```js
-log('Script ' + name + ' started by ' + instance + '!');
+log(`Script ${scriptName} started started by ${instance}`);
+```
+
+### defaultDataDir
+`defaultDataDir` - Absolute path to iobroker-data.
+
+```js
+log(`Data dir: ${defaultDataDir}`);
+```
+
+### verbose
+`verbose` - Verbose mode enabled?
+
+```js
+log(`Verbose mode: ${verbose ? 'enabled' : 'disabled'}`);
+
+// Example
+if (verbose) {
+    log('...');
+}
 ```
 
 ## Option - "Do not subscribe all states on start"

--- a/lib/javascript.d.ts
+++ b/lib/javascript.d.ts
@@ -1067,6 +1067,12 @@ declare global {
 			setStateDelayed(state: any, isAck?: boolean, delay?: number, clearRunning?: boolean, callback?: SetStateCallback): this;
 
 			/**
+			 * Sets all queried states to the given value only if the value really changed.
+			 */
+			setStateChanged(state: State | StateValue | SettableState, ack?: boolean, callback?: SetStateCallback): this;
+			setStateChangedAsync(state: State | StateValue | SettableState, ack?: boolean): Promise<void>;
+
+			/**
 			 * Subscribes the given callback to changes of the matched states.
 			 */
 			on(callback: StateChangeHandler): this;
@@ -1294,7 +1300,7 @@ declare global {
 	/**
 	 * Sends an email using the email adapter.
 	 * See the adapter documentation for a description of the msg parameter.
-	 * 
+	 *
 	 * @deprecated Use @see sendTo
 	 */
 	function email(msg: any): void;
@@ -1302,7 +1308,7 @@ declare global {
 	/**
 	 * Sends a pushover message using the pushover adapter.
 	 * See the adapter documentation for a description of the msg parameter.
-	 * 
+	 *
 	 * @deprecated Use @see sendTo
 	 */
 	function pushover(msg: any): void;
@@ -1419,7 +1425,7 @@ declare global {
 
 	/**
 	 * [{"type":"cron","pattern":"0 15 13 * * *","scriptName":"script.js.scheduleById","id":"cron_1704187467197_22756"}]
-	 * 
+	 *
 	 * @param allScripts Return all registered schedules of all running scripts
 	 */
 	function getSchedules(allScripts?: boolean): Array<iobJS.ScheduleStatus>;
@@ -1458,6 +1464,16 @@ declare global {
 	function setState(id: string, state: iobJS.State | iobJS.StateValue | iobJS.SettableState, ack: boolean, callback?: iobJS.SetStateCallback): void;
 
 	function setStateAsync(id: string, state: iobJS.State | iobJS.StateValue | iobJS.SettableState, ack?: boolean): iobJS.SetStatePromise;
+
+	/**
+	 * Sets a state to the given value only if the value really changed.
+	 * @param id The ID of the state to be set
+	 */
+	function setStateChanged(id: string, state: iobJS.State | iobJS.StateValue | iobJS.SettableState, callback?: iobJS.SetStateCallback): void;
+	function setStateChanged(id: string, state: iobJS.State | iobJS.StateValue | iobJS.SettableState, ack: boolean, callback?: iobJS.SetStateCallback): void;
+
+	function setStateChangedAsync(id: string, state: iobJS.State | iobJS.StateValue | iobJS.SettableState, ack?: boolean): iobJS.SetStatePromise;
+
 
 	/**
 	 * Sets a state to the given value after a timeout has passed.

--- a/lib/sandbox.js
+++ b/lib/sandbox.js
@@ -460,7 +460,8 @@ function sandBox(script, name, verbose, debug, context) {
                 if (!adapter.config.subscribe) {
                     // store actual state to make possible to process value in callback
                     // risk that there will be an error on setState is very low
-                    context.interimStateValues[id] = state;
+                    // but we will not store new state if the setStateChanged is called
+                    if (!isChanged) context.interimStateValues[id] = state;
                 }
                 const errHandler = (err, funcId) => {
                     err && sandbox.log(`${funcId}: ${err}`, 'error');
@@ -479,7 +480,23 @@ function sandBox(script, name, verbose, debug, context) {
                         });
                     }};
                 if (isChanged) {
-                    adapter.setForeignStateChanged(id, {...state, ts: undefined}, err => errHandler(err, 'setForeignStateChanged'));
+                    if (!adapter.config.subscribe && context.interimStateValues[id] ) {
+                        // if state is changed, we will compare it with interimStateValues
+                        const oldState = context.interimStateValues[id],
+                            attrs = Object.keys(state).filter(attr => attr !== 'ts' && state[attr] !== undefined);
+                        if (attrs.every(attr => state[attr] === oldState[attr]) === false) {
+                            // state is changed for sure and we will call setForeignState
+                            // and store new state to interimStateValues
+                            context.interimStateValues[id] = state;
+                            adapter.setForeignState(id, state, err => errHandler(err, 'setForeignState'));
+                        } else {
+                          // otherwise - do nothing as we have cached state, except callback
+                          errHandler(null, 'setForeignStateCached')
+                        }
+                    } else {
+                        // adapter not holds all states or it has not cached, then we will simple call setForeignStateChanged
+                        adapter.setForeignStateChanged(id, {...state, ts: undefined}, err => errHandler(err, 'setForeignStateChanged'));
+                    }
                 } else {
                     adapter.setForeignState(id, state, err => errHandler(err, 'setForeignState'));
                 }

--- a/lib/sandbox.js
+++ b/lib/sandbox.js
@@ -341,7 +341,7 @@ function sandBox(script, name, verbose, debug, context) {
         }
     }
 
-    function setStateHelper(sandbox, isCreate, id, state, isAck, callback) {
+    function setStateHelper(sandbox, isCreate, isChanged, id, state, isAck, callback) {
         if (typeof isAck === 'function') {
             callback = isAck;
             isAck = undefined;
@@ -462,8 +462,8 @@ function sandBox(script, name, verbose, debug, context) {
                     // risk that there will be an error on setState is very low
                     context.interimStateValues[id] = state;
                 }
-                adapter.setForeignState(id, state, err => {
-                    err && sandbox.log(`setForeignState: ${err}`, 'error');
+                const errHandler = (err, funcId) => {
+                    err && sandbox.log(`${funcId}: ${err}`, 'error');
                     // If adapter holds all states
                     if (err && !adapter.config.subscribe) {
                         delete context.interimStateValues[id];
@@ -477,8 +477,12 @@ function sandBox(script, name, verbose, debug, context) {
                                 errorInCallback(e);
                             }
                         });
-                    }
-                });
+                    }};
+                if (isChanged) {
+                    adapter.setForeignStateChanged(id, state, err => errHandler(err, 'setForeignStateChanged'));
+                } else {
+                    adapter.setForeignState(id, state, err => errHandler(err, 'setForeignState'));
+                }
             }
         } else {
             context.logWithLineInfo && context.logWithLineInfo.warn(`State "${id}" not found`);
@@ -965,6 +969,21 @@ function sandBox(script, name, verbose, debug, context) {
             result.setStateAsync = async function (state, isAck) {
                 for (let i = 0; i < this.length; i++) {
                     await sandbox.setStateAsync(this[i], state, isAck);
+                }
+            };
+            result.setStateChanged = function (state, isAck, callback) {
+                if (typeof isAck === 'function') {
+                    callback = isAck;
+                    isAck = undefined;
+                }
+                result.setStateChangedAsync(state, isAck)
+                    .then(() =>
+                        typeof callback === 'function' && callback());
+                return this;
+            };
+            result.setStateChangedAsync = async function (state, isAck) {
+                for (let i = 0; i < this.length; i++) {
+                    await sandbox.setStateChangedAsync(this[i], state, isAck);
                 }
             };
             result.setStateDelayed = function (state, isAck, delay, clearRunning, callback) {
@@ -1890,7 +1909,10 @@ function sandBox(script, name, verbose, debug, context) {
             return schedules;
         },
         setState: function (id, state, isAck, callback) {
-            return setStateHelper(sandbox, false, id, state, isAck, callback);
+            return setStateHelper(sandbox, false, false, id, state, isAck, callback);
+        },
+        setStateChanged: function (id, state, isAck, callback) {
+            return setStateHelper(sandbox, false, true, id, state, isAck, callback);
         },
         setStateDelayed: function (id, state, isAck, delay, clearRunning, callback) {
             // find arguments
@@ -2074,7 +2096,11 @@ function sandBox(script, name, verbose, debug, context) {
         },
         setStateAsync: function (id, state, isAck) {
             return new Promise((resolve, reject) =>
-                setStateHelper(sandbox, false, id, state, isAck, err => err ? reject(err) : resolve()));
+                setStateHelper(sandbox, false, false, id, state, isAck, err => err ? reject(err) : resolve()));
+        },
+        setStateChangedAsync: function (id, state, isAck) {
+            return new Promise((resolve, reject) =>
+                setStateHelper(sandbox, false, true, id, state, isAck, err => err ? reject(err) : resolve()));
         },
         getState: function (id, callback) {
             if (typeof callback === 'function') {
@@ -2725,12 +2751,12 @@ function sandBox(script, name, verbose, debug, context) {
 
                 if (!isAlias && initValue !== undefined) {
                     if (isObject(initValue) && initValue.ack !== undefined) {
-                        setStateHelper(sandbox, true, id, initValue, callback);
+                        setStateHelper(sandbox, true, false, id, initValue, callback);
                     } else {
-                        setStateHelper(sandbox, true, id, initValue, true, callback);
+                        setStateHelper(sandbox, true, false, id, initValue, true, callback);
                     }
                 } else if (!isAlias && !forceCreation) {
-                    setStateHelper(sandbox, true, id, null, callback);
+                    setStateHelper(sandbox, true, false, id, null, callback);
                 } else if (isAlias) {
                     try {
                         const state = await adapter.getForeignStateAsync(id);

--- a/lib/sandbox.js
+++ b/lib/sandbox.js
@@ -479,7 +479,7 @@ function sandBox(script, name, verbose, debug, context) {
                         });
                     }};
                 if (isChanged) {
-                    adapter.setForeignStateChanged(id, state, err => errHandler(err, 'setForeignStateChanged'));
+                    adapter.setForeignStateChanged(id, {...state, ts: undefined}, err => errHandler(err, 'setForeignStateChanged'));
                 } else {
                     adapter.setForeignState(id, state, err => errHandler(err, 'setForeignState'));
                 }

--- a/lib/sandbox.js
+++ b/lib/sandbox.js
@@ -490,8 +490,8 @@ function sandBox(script, name, verbose, debug, context) {
                             context.interimStateValues[id] = state;
                             adapter.setForeignState(id, state, err => errHandler(err, 'setForeignState'));
                         } else {
-                          // otherwise - do nothing as we have cached state, except callback
-                          errHandler(null, 'setForeignStateCached')
+                            // otherwise - do nothing as we have cached state, except callback
+                            errHandler(null, 'setForeignStateCached');
                         }
                     } else {
                         // adapter not holds all states or it has not cached, then we will simple call setForeignStateChanged


### PR DESCRIPTION
Notise: looks like the `adapter.setForeignStateChanged` use the `state.ts` value to compare, as result, it always be changed.
https://github.com/ioBroker/ioBroker.js-controller/blob/5f3c5bf6099dd086b20dcd9daf67e17ac5bcb31f/packages/adapter/src/lib/adapter/adapter.ts#L8000
There are two possibility to solve - to request change in ioBroker.js-controller, or make own comparison of new and old state attributes.