### PR TITLE
Make `node:fs` `constants` available thru the `protectFS`

### DIFF
--- a/lib/protectFs.js
+++ b/lib/protectFs.js
@@ -377,6 +377,9 @@ const ProtectFs = function (log, ioBrokerDataDir) {
         }
     };
 
+    // Add missing constants
+    this.constants = nodeFS.constants;
+
     // Add missing functions
     for (const m in nodeFS) {
         if (typeof nodeFS[m] === 'function' && Object.hasOwn(nodeFS, m) && !Object.hasOwn(this, m)) {


### PR DESCRIPTION
Due to all missed functions from the `node:fs` is processed automatically for types `function`, the `constants` object has to be processed separately.