### PR TITLE
This PR is implementing the another "result" function for the `$` (`selector`) function .

### DIFF
--- a/docs/en/javascript.md
+++ b/docs/en/javascript.md
@@ -1352,6 +1352,7 @@ Sends to an adapter the message `unsubscribe` to inform adapter to not poll the 
 ### $ - Selector
 ```js
 $(selector).on(function(obj) {});
+$(selector).toArray();
 $(selector).each(function(id, i) {});
 $(selector).setState(value, ack);
 $(selector).getState();
@@ -1396,7 +1397,7 @@ Find all channels with `common.role="switch"` and belongs to `enum.rooms.Wohnzim
 Take all their states, where id ends with `".STATE"` and make subscription on all these states.
 If some of these states change, the callback will be called like for "on" function.
 
-Following functions are possible, setState, getState (only from first), on, each
+Following functions are possible, setState, getState (only from first), on, each, toArray
 
 ```js
 // Switch on all switches in "Wohnzimmer"
@@ -1412,6 +1413,11 @@ $('channel[role=switch][state.id=*.STATE](rooms=Wohnzimmer)').each((id, i) => {
         return false;
     }
 });
+```
+Or you can get a an usual array of ids and process it your own way:
+```js
+// get some state and filter only which has an `true` value
+const enabled = $('channel[role=switch][state.id=*.STATE](rooms=Wohnzimmer)').toArray().filter((id) => getState(id)?.val === true);
 ```
 
 ### readFile

--- a/lib/javascript.d.ts
+++ b/lib/javascript.d.ts
@@ -1044,6 +1044,11 @@ declare global {
 			error?: string;
 
 			/**
+			 * Return the result as an array of state ids
+			 */
+			toArray(): Array<string>;
+
+			/**
 			 * Executes a function for each state id in the result array
 			 * The execution is canceled if a callback returns false
 			 */

--- a/lib/sandbox.js
+++ b/lib/sandbox.js
@@ -643,6 +643,9 @@ function sandBox(script, name, verbose, debug, context) {
             // If some error in the selector
             if (selectorHasInvalidType || isInsideEnumString || isInsideCommonString || isInsideNativeString) {
                 result.length = 0;
+                result.toArray = function () {
+                    return [];
+                };
                 result.each = function () {
                     return this;
                 };
@@ -931,6 +934,9 @@ function sandBox(script, name, verbose, debug, context) {
                 for (let i = 0; i < result.length; i++) {
                     yield result[i];
                 }
+            };
+            result.toArray = function () {
+                return [...resUnique];
             };
             result.each = function (callback) {
                 if (typeof callback === 'function') {


### PR DESCRIPTION
The new "result" function `toArray()` returns an `array of strings` which is an usual array with has all selected `id's` and you can apply all appropriate arrays methods to it.
The reason of this PR - in some cases, you need to get the array of strings from the `selector`, instead of use the current `each` iterator. Moreover, the source data already presented as an array of strings, so you don't need to iterate it once more time.
Changed files:
- `lib/javascript.d.ts`: updated declaration of `$` - the `toArray() is added;
- `lib/sandbox.js`: implementation of the `toArray()` function;
- `test/testFunctions.js`: test added for the `toArray()` function;
- `docs/en/javascript.md`: documentation updates of the `$` function description.