### PR TITLE
fixed issue in importing additional node modules for packages which do not provide a default export (e.g. 'mathjs')

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Executes Javascript, Typescript Scripts.
 * (klein0r) Escape all field inputs correctly when using single quotes
 * (klein0r) Added sandbox functions to start/restart/stop an instance
 * (klein0r) Added Blockly block to start/restart/stop an instance
+* (foxriver76) fixed issue in importing additional node modules for packages which do not provide a default export (e.g. `mathjs`)
 
 ### 8.6.0 (2024-06-14)
 

--- a/main.js
+++ b/main.js
@@ -1872,7 +1872,9 @@ async function installLibraries() {
                 if (result.success) {
                     adapter.log.debug(`Installed custom dependency: "${moduleName}@${version}"`);
 
-                    context.mods[moduleName] = (await adapter.importNodeModule(moduleName)).default;
+                    const importedModule = await adapter.importNodeModule(moduleName);
+
+                    context.mods[moduleName] = importedModule.default ?? importedModule;
                 } else {
                     adapter.log.warn(`Cannot install custom npm package "${moduleName}@${version}"`);
                 }

--- a/main.js
+++ b/main.js
@@ -1873,7 +1873,6 @@ async function installLibraries() {
                     adapter.log.debug(`Installed custom dependency: "${moduleName}@${version}"`);
 
                     const importedModule = await adapter.importNodeModule(moduleName);
-
                     context.mods[moduleName] = importedModule.default ?? importedModule;
                 } else {
                     adapter.log.warn(`Cannot install custom npm package "${moduleName}@${version}"`);


### PR DESCRIPTION
- so logic is - if default export provided use it, else use the imported module itself