### PR TITLE
Update javascript.md - stopSrcipt: Call without arguments brings an error message

### DIFF
--- a/docs/en/javascript.md
+++ b/docs/en/javascript.md
@@ -1672,10 +1672,10 @@ startScript('scriptName', true); // start script if not started
 stopScript('scriptName', callback);
 ```
 
-If stopScript is called without arguments, it will stop itself:
+If stopScript is called with an empty string, it will stop itself:
 
 ```js
-stopScript();
+stopScript('');
 ```
 
 ### stopScriptAsync


### PR DESCRIPTION
stopSrcipt: Call without arguments brings the error message, that 1 or 2 arguments are expected. With the empty string it stops itself.