### PR TITLE
fix: correct typo 'Letze Änderung' to 'Letzte Änderung'

### DIFF
--- a/src-editor/public/i18n/de/flat.txt
+++ b/src-editor/public/i18n/de/flat.txt
@@ -152,7 +152,7 @@ ID auswählen
 Wert
 bestätigt
 Zeitstempel
-Letze Änderung
+Letzte Änderung
 Qualität
 Wertkommentar
 Quelle


### PR DESCRIPTION
This PR fixes a small typo in the German translation file.

Changed:
- "Letze Änderung" → "Letzte Änderung"

File updated: src-editor/public/i18n/de/flat.txt
closes #2012 