### PR TITLE
Fix script tree folder icon size

### DIFF
--- a/src-editor/src/SideMenu.tsx
+++ b/src-editor/src/SideMenu.tsx
@@ -151,8 +151,8 @@ const styles: Record<string, any> = {
         transitionProperty: 'opacity',
     },
     folderIcon: {
-        width: 20,
-        height: 20,
+        width: 28,
+        height: 28,
     },
     folderIconReorder: {
         paddingTop: 4,


### PR DESCRIPTION
## What changed
- increase the folder SVG dimensions in the script tree so folder icons have the same visual size as script icons

## Scope
- Only `src-editor/src/SideMenu.tsx`
- No generated admin bundles or unrelated files

## Validation
- TypeScript check (`npm run tsc`) passed
- Addresses issue #2360